### PR TITLE
Document the client/repo docs split decision

### DIFF
--- a/meta/decisions/client-repo-split.md
+++ b/meta/decisions/client-repo-split.md
@@ -1,0 +1,5 @@
+# Split documentation for client(s) and repo
+
+Within the Wikidata context there are two types of systems: the structured data repository (Wikidata) storing and providing structured data, and clients (Wikipedias, Wiktionaries, ...) consuming the data provided by Wikidata. Since both clients and the repo each have different requirements, constraints, and stakeholders, we decided to split the documentation for the sake of clarity.
+
+While Wikimedia Commons is also a repository, it is not considered the primary focus of this documentation. The documentation of the repository system will mainly refer to Wikidata.


### PR DESCRIPTION
I thought it would be good to document the decision to cut the documentation in two (#8). The phrasing is very Wikimedida-centric. Do you think it would be better to phrase it in a fluffier Wikibase-y way?