### PR TITLE
Document mw extensions constraint

### DIFF
--- a/12-Glossary.md
+++ b/12-Glossary.md
@@ -47,3 +47,7 @@ Lua is a programming language that can be embedded into [Wikitext](https://www.m
 ## [Wikitext](https://en.wikipedia.org/wiki/Help:Wikitext)
 
 Wikitext, also known as Wiki markup or Wikicode, consists of the syntax and keywords used by the MediaWiki software to format a page. It's what editors work with to create and edit wiki articles.
+
+## [MediaWiki Core](https://www.mediawiki.org/wiki/Core)
+
+MediaWiki Core refers to all files that are part of the main MediaWiki package.

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ A high level [arc42 template](https://docs.arc42.org/home/) connects all of the 
 
 ## High level Contents
 
-1. [Introduction and goals: Requirements, stakeholder, (top) quality goals](./01-Introduction&#32;and&#32;Goals.md)
-2. [Constraints: Technical and organizational constraints, conventions](./02-Architecture&#32;Constraints.md)
-3. [Context and scope: Business and technical context, external interfaces](./03-Context&#32;and&#32;Scope.md)
-4. [Solution strategy: Fundamental solution decisions and ideas](./04-Solution&#32;Strategy.md)
-5. [Building block view: Abstractions of source code, black-/whiteboxes](./05-Building&#32;Block&#32;View.md)
-6. [Runtime view: Runtime scenarios: How do building blocks interact](./06-Runtime&#32;View.md)
-7. [Deployment view: Hardware and technical infrastructure, deployment](./07-Deployment&#32;View.md)
+1. [Introduction and goals: Requirements, stakeholder, (top) quality goals](<./01-Introduction and Goals.md>)
+2. [Constraints: Technical and organizational constraints, conventions](<./02-Architecture Constraints.md>)
+3. [Context and scope: Business and technical context, external interfaces](<./03-Context and Scope.md>)
+4. [Solution strategy: Fundamental solution decisions and ideas](<./04-Solution Strategy.md>)
+5. [Building block view: Abstractions of source code, black-/whiteboxes](<./05-Building Block View.md>)
+6. [Runtime view: Runtime scenarios: How do building blocks interact](<./06-Runtime View.md>)
+7. [Deployment view: Hardware and technical infrastructure, deployment](<./07-Deployment View.md>)
 8. [Crosscutting concepts: Recurring solution approaches and patterns](./08-Concepts.md)
-9. [Architecture decisions: Important decisions](./09-Architecture&#32;Decisions.md)
+9. [Architecture decisions: Important decisions](<./09-Architecture Decisions.md>)
 10. [Quality: Quality tree and quality scenarios](./10-Quality.md)
-11. [Risks and technical debt: Known problems, risks and technical debt](./11-Risks&#32;and&#32;Technical&#32;Debt.md)
+11. [Risks and technical debt: Known problems, risks and technical debt](<./11-Risks and Technical Debt.md>)
 12. [Glossary: Definitions of important business and technical terms](./12-Glossary.md)
 
 ## Subsystems

--- a/subsystems/WikibaseClient/02-Architecture Constraints.md
+++ b/subsystems/WikibaseClient/02-Architecture Constraints.md
@@ -1,3 +1,6 @@
 # Architecture Constraints
 
+## [MediaWiki Extensions](./12-Glossary.md/#mediawiki-extension )
 
+Any functionality that doesn't belong in [MediaWiki core](https://www.mediawiki.org/wiki/Core) has to be registered as a mediawiki extension.
+**Mediawiki extensions cannot have extensions of their own.**

--- a/subsystems/WikibaseRepo/02-Architecture Constraints.md
+++ b/subsystems/WikibaseRepo/02-Architecture Constraints.md
@@ -1,3 +1,2 @@
 # Architecture Constraints
 
-


### PR DESCRIPTION
Document mw extensions constraint both in client and repo subsystems.
Add a definition of mediawiki core to Glossary.

p.s. This is the same as the old PR + the feedback incorporated. I managed to completely butcher :hocho: the rebase on the other one so I closed it. 