### PR TITLE
Increase the default page max-width in vuepress

### DIFF
--- a/.vuepress/styles/palette.styl
+++ b/.vuepress/styles/palette.styl
@@ -1,0 +1,1 @@
+$contentWidth = 80%


### PR DESCRIPTION
Increasing the width of the content pages allows for better readibility of our diagrams and tables.
See Building Block View for example.