### PR TITLE
WikibaseClient: add technical context diagram

### DIFF
--- a/systems/WikibaseClient/03-Context_and_Scope.md
+++ b/systems/WikibaseClient/03-Context_and_Scope.md
@@ -2,7 +2,7 @@
 
 ### Business Context
 
-![Alt Text](./diagrams/03-business-context.drawio.svg)
+![WikibaseClient business context diagram](./diagrams/03-business-context.drawio.svg)
 
 | Neighbour             | Description                |
 | --------------------- | -------------------------- |
@@ -10,3 +10,5 @@
 | Wikibase Repo         | A Wikibase Repository that the Client connects to |
 
 ### Technical Context
+
+![WikibaseClient technical context diagram](./diagrams/03-technical-context.drawio.svg)

--- a/systems/WikibaseClient/diagrams/03-technical-context.drawio.svg
+++ b/systems/WikibaseClient/diagrams/03-technical-context.drawio.svg
@@ -1,0 +1,378 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="931px" height="394px" viewBox="-0.5 -0.5 931 394" content="&lt;mxfile host=&quot;2d4082ca-a96d-4ab3-9644-c82f1645c429&quot; modified=&quot;2021-01-12T14:29:46.558Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;qX21sw54IV6yh-LYRNS0&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;ZZAaw9F9bndAv2IfB5-a&quot; name=&quot;Page-1&quot;&gt;3Vzfc5s4EP5rPNN7CAMICXiMk/6aaW8y13bae8RGttVg5AO5SfrXnwSSjSSckAQIjftQWJCA3dW3366kzMDF9vZ9kew2n2mKs5nvprczcDnzfS/0Av6fkNxJiQejWrIuSCplR8EX8htLoSule5LiUruRUZoxstOFS5rneMk0WVIU9Ea/bUUz/am7ZI0twZdlktnS7yRlGymFrnu88AGT9YaZV7aJulsKyk2S0puGCLydgYuCUlYfbW8vcCbUpxRTt3t34urhzQqcsy4NoLTFryTby6/7jFOSfCfXRL4hu1PfXdB9nmLR0p2B+eHVPX6yojmThvJceX5BM1pULYFb/UQjVtBrrK7kNOct5ikpuJkIzbnoBpdMtCdZ1mg/Pxf/uPwXLhjhljjPyFrczuiOS+2vlooQt+Pbhkhq4T2mW8yKO36LvIqURaRTAiTPb44WDmIp2zSM60MpTKRXrQ99H/XOD6Tq283gW1YQBlgkJebSf/COTtEWA2gdhS1aj1q0HvWgdC+2tG6pGefpuUAMfrbI6PL664bkluqaSn2c8hV8CLPxR70j4mXlGf+aH9K81cm/4sSB6vTytnnx8k6d3RL2o3FctwLGT1489iFOml1c4YJwheJCORhLCtauCX6h8d4nnaKk+2IptYok6vC2ayxvg7CW4VQDX9t1Gq4BWzxDyQqcJYz80iG7zV3kE64o4W988Ezo6Z4ZBIbH1d8jWzUR1ugIuYaLmx3VSrA6qrz38NndUMSGEd4pLpIlKyvFcb35KNkKyMwX5a52HsKEVtOEJTOfPwJlYswvCn60FkfbhOSZuINtOOasN1VHIjjwUMqhOOOB2Grz5gYv+A3fPv5lDyhu3k/JglMCMN+wrXKbROL5EueV01lAvyVpKvqYF7gkv5NF1Z/wzJ1QXKVKOJ/By3YXjDVCIFsfo3B3wHIdH0RIM+iZ14vDnXmhA/WOfc9xtV+gd0pXqxI/22k8y2lU7LnICJZO+cTQY+Fk5C8AQp3iTApxlAY9xRmgD8IDIWvGmbAFTTy3j+geP6BDWrANXdM8yT5RQWgqXf7EjN1JZSZ7RvUBcyIwGUFEBYM6bKhwcC/6dwLwANoAHqCOAP7MgcJNEuuI6vpO5D8Nne3OQruz/hAa2Aj9hTCckfxawNMmydetePqTCjz9b4/3eCKQqnzaGoOnUPY+SHVd0AuGeo4f6BAaOnE0AGiCYIgRrRjfkeRJzhf4D7G+IxpIHn8EgkfRN52WHh5r0sHhgAW0AEswDrCEZpCIgYOMkNsVV0LgG9E8DOzeegQWaAHLW53aWZhSR2B+/XIuXmm5xGU5EXBRw6sPvuYFfjgEX3OdWPupoKGeEjvREHQNvBiXOAFP3kPQNBhUqNJfEyr8sThIbGR1rvcMDmJ0FkLeGTrSfuP1+kMNlYqeRg13v+MHrZxkw9huMoDRZ4L3x7GRwE7hLmvrzQsiRkKfGVyKFgh2y+BWq5W/XPaTwXmuUZCB4XHENbK4tmKhb4/Np6RxClwaaj6/+vgqldtWhx1Ss8DS7Kc99993V0lRcrTw3dU+r9XxCrQdtnmy16ASo6rengCq5xsqWtijsmMUgqSbsrGXQhwOo+yxPdvm5d+qiCqUfMZjKf/cSl8fKL3+kOQ8BBavwcfjl0drdI/mX6OKR/ZsaHPHi6p+9Yq8OJoSUkOb5R3IOk4Ja4DJhoNJ+RoNMLaP+w8ocexk+5hePybZVlMBz0i2YUuyrRBg6GQ7goYTIGNOpmuiHQWxE3p6X26s13H0nvtLtaFNcWu4/JsysuKJcM1u/4DKvxoUk6r8u47naXaMIs3OkeMaeNBL5g1teneVVFM47mGmnR9fcHjteyb1pRAZ6YMx8I0BFIwK0OilAFoCrTfrWtN8av20Gzy3zceCkeDZqF4GoastWzA67AzWRrcwQA5Ag8FzaA1kVpD1GhfclRprX0x8Fksl+MhhtYlKkq9bMJz7D79c0AnNsKiBMykQPwNOBDSjn3F0cV0N14dA8ejlaV44EZ7ntvC8rivzngskRmhB5iLPztBhduQCB4ExSJ69ovQwf+LytNjGht2+qOjCJDAhmiAmeE4MNH6hz6q7TtB6uVd8UO70guu3/O6Tp+MTjbHwITSIBjKqMU9eq6FTWD1zgFFrzad/8EB2fUeusOXCLeVq89+lOMPtiWJ7yedFcEQNl0nhiAUkupXP/MBxoyZtHSJdRPZky7eypVTKM8GdONxvs/Mlo00LVda8oiWRGd+CMka3LSasd8Y0jE73LCM5TyHVpqh7B/0jJg+BuVTet4t0oCUHNMs4T0kAkZ2A24Pg5fdwSPx+9JqZJug/fxPHSWNraO51RPNx9mF4wNgiFJj7rbrCfAytjpzYG2GVDbJnokS9XnDCjwxvK2flHHGLBbJOfi+FGnFT3kvhQyfQE0kPOgC1lKn6hXe7iPBlh5ckETfJuuCfXwG0V+J4esHHRRb8D1gCRJGl9ClGAC27b4XyR8cDeH8AaFu3fdL82u680I4KirlMJioAMxd4YlTwOOvTvFfPLyv2759khT0GCbt0cNibty/FhnSeBOBqUR/JV7TYnpowmlq4iKYfLs4C5PhadNAfEzmeljqAAWKHym1f3+LCw4bXY7gYMz6Edlo9p4Jo8ZbuV0ozefg+4cOD2RH6j8rFAviwrodKxUKb5k4wEB9OnhWItWm/wQKxwoRmIA6nlZ4hoyYH4yfG4cDXw3Bg7J7yRorDoc3hD3H4jQjAPK6e2lE1pR0RajROOe6Ok6bx0+Pf06lvP/5dIvD2fw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <rect x="210" y="0" width="490" height="250" fill="#000000" stroke="none" transform="translate(2,3)rotate(180,455,125)" opacity="0.25"/>
+        <rect x="210" y="0" width="490" height="250" fill="#bababa" stroke="none" transform="rotate(180,455,125)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="454.5" y="15.5">
+                MediaWiki
+            </text>
+        </g>
+        <rect x="210" y="310" width="480" height="80" fill="#000000" stroke="none" transform="translate(2,3)rotate(180,450,350)" opacity="0.25"/>
+        <rect x="210" y="310" width="480" height="80" fill="#bababa" stroke="none" transform="rotate(180,450,350)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="449.5" y="353.5">
+                Wikibase Repo
+            </text>
+        </g>
+        <path d="M 891.88 80.02 L 538.12 80.89" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 898.88 80 L 891.89 82.35 L 891.88 77.69 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 531.12 80.91 L 538.11 78.56 L 538.12 83.22 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 59px; margin-left: 654px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                interacts with entity data,
+                                <br/>
+                                mainly through wiki articles
+                                <br/>
+                                (web UI)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="654" y="62" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    interacts with entity data,...
+                </text>
+            </switch>
+        </g>
+        <rect x="220" y="140" width="470" height="100" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,455,190)" opacity="0.25"/>
+        <rect x="220" y="140" width="470" height="100" fill="#d5e8d4" stroke="#82b366" transform="rotate(180,455,190)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="454.5" y="193.5">
+                WikibaseClient
+            </text>
+        </g>
+        <path d="M 540 233.64 L 540 301.88" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 540 308.88 L 537.67 301.88 L 542.33 301.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 272px; margin-left: 542px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                Sitelink changes
+                                <br/>
+                                (job queue)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="542" y="275" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    Sitelink changes...
+                </text>
+            </switch>
+        </g>
+        <path d="M 340 243.88 L 340 319.99" fill="none" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 340 235.88 L 342.67 243.88 L 337.33 243.88 Z" fill="#000000" stroke="#000000" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 273px; margin-left: 341px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                Entity data
+                                <br/>
+                                (direct DB access)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="341" y="277" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    Entity data...
+                </text>
+            </switch>
+        </g>
+        <path d="M 640 233.64 L 640 301.88" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 640 308.88 L 637.67 301.88 L 642.33 301.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 272px; margin-left: 642px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                Entity data updates
+                                <br/>
+                                (https)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="642" y="275" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    Entity data updates...
+                </text>
+            </switch>
+        </g>
+        <rect x="600" y="211.82" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,640,222.73)" opacity="0.25"/>
+        <rect x="600" y="211.82" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,640,222.73)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="639.5" y="226.23">
+                Data Bridge
+            </text>
+        </g>
+        <rect x="600" y="310" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,640,320.91)" opacity="0.25"/>
+        <rect x="600" y="310" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,640,320.91)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="639.5" y="324.41">
+                API
+            </text>
+        </g>
+        <rect x="300" y="211.82" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,340,222.73)" opacity="0.25"/>
+        <rect x="300" y="211.82" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,340,222.73)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="339.5" y="226.23">
+                Lua/Parser function
+            </text>
+        </g>
+        <rect x="300" y="310" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,340,320.91)" opacity="0.25"/>
+        <rect x="300" y="310" width="80" height="21.82" fill="#e1d5e7" stroke="#9673a6" transform="rotate(180,340,320.91)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="339.5" y="324.41">
+                Repo DB
+            </text>
+        </g>
+        <rect x="500" y="211.82" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,540,222.73)" opacity="0.25"/>
+        <rect x="500" y="211.82" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,540,222.73)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="539.5" y="220.23">
+                UpdateRepo-
+            </text>
+            <text x="539.5" y="232.23">
+                HookHandler
+            </text>
+        </g>
+        <rect x="500" y="310" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,540,320.91)" opacity="0.25"/>
+        <rect x="500" y="310" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,540,320.91)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="539.5" y="324.41">
+                UpdateRepo
+            </text>
+        </g>
+        <rect x="400" y="211.82" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,440,222.73)" opacity="0.25"/>
+        <rect x="400" y="211.82" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,440,222.73)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="439.5" y="226.23">
+                ChangeHandler
+            </text>
+        </g>
+        <rect x="400" y="310" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,440,320.91)" opacity="0.25"/>
+        <rect x="400" y="310" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,440,320.91)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="439.5" y="318.41">
+                Entity edit
+            </text>
+            <text x="439.5" y="330.41">
+                hooks
+            </text>
+        </g>
+        <path d="M 440 310 L 440 241.76" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 440 234.76 L 442.33 241.76 L 437.67 241.76 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 273px; margin-left: 441px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                ChangeNotification
+                                <br/>
+                                (job queue)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="441" y="276" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    ChangeNotification...
+                </text>
+            </switch>
+        </g>
+        <rect x="450" y="70" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,490,80.91)" opacity="0.25"/>
+        <rect x="450" y="70" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,490,80.91)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="489.5" y="84.41">
+                Pages &amp; Content
+            </text>
+        </g>
+        <path d="M 450 91.82 L 345.49 205.84" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 340.76 211 L 343.77 204.26 L 347.21 207.41 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 136px; margin-left: 380px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                triggered through
+                                <br/>
+                                Wikitext parsing
+                                <br/>
+                                (in process)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="380" y="139" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    triggered through...
+                </text>
+            </switch>
+        </g>
+        <path d="M 440 211.82 L 468.03 99.7" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 469.73 92.9 L 470.29 100.26 L 465.77 99.13 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 141px; margin-left: 460px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                updates and
+                                <br/>
+                                purges
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="460" y="144" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    updates and...
+                </text>
+            </switch>
+        </g>
+        <path d="M 510 91.82 L 538.03 203.94" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 539.73 210.74 L 535.77 204.51 L 540.29 203.38 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 140px; margin-left: 550px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                article move/deletion
+                                <br/>
+                                hooks
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="550" y="143" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    article move/deletion...
+                </text>
+            </switch>
+        </g>
+        <ellipse cx="915" cy="67.5" rx="7.5" ry="7.5" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <path d="M 915 75 L 915 100 M 915 80 L 900 80 M 915 80 L 930 80 M 915 100 L 900 120 M 915 100 L 930 120" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 127px; margin-left: 915px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                User
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="915" y="139" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    User
+                </text>
+            </switch>
+        </g>
+        <path d="M 910 90 L 667.3 208.26" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 661.01 211.33 L 666.28 206.17 L 668.32 210.36 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 180px; margin-left: 781px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                edits Item statements
+                                <br/>
+                                (web UI)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="781" y="184" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    edits Item statements...
+                </text>
+            </switch>
+        </g>
+        <rect x="600" y="150" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,640,160.91)" opacity="0.25"/>
+        <rect x="600" y="150" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,640,160.91)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="639.5" y="164.41">
+                Special Pages
+            </text>
+        </g>
+        <path d="M 680 160.91 L 892.38 82.8" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 898.95 80.39 L 893.19 84.99 L 891.58 80.61 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 120px; margin-left: 771px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                entity usage meta information
+                                <br/>
+                                (web UI)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="771" y="124" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    entity usage meta information...
+                </text>
+            </switch>
+        </g>
+        <rect x="230" y="150" width="80" height="21.82" fill="#000000" stroke="#000000" transform="translate(2,3)rotate(180,270,160.91)" opacity="0.25"/>
+        <rect x="230" y="150" width="80" height="21.82" fill="#fff2cc" stroke="#d6b656" transform="rotate(180,270,160.91)" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="10px">
+            <text x="269.5" y="164.41">
+                API
+            </text>
+        </g>
+        <ellipse cx="55" cy="157.5" rx="7.5" ry="7.5" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+        <path d="M 55 165 L 55 190 M 55 170 L 40 170 M 55 170 L 70 170 M 55 190 L 40 210 M 55 190 L 70 210" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 217px; margin-left: 55px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                Bots, Tools, Gadgets
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="55" y="229" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Bots,...
+                </text>
+            </switch>
+        </g>
+        <path d="M 230 160.91 L 78.1 169.54" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 71.12 169.94 L 77.97 167.21 L 78.24 171.87 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 181px; margin-left: 157px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
+                                entity (meta) data
+                                <br/>
+                                (https)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="157" y="185" fill="#000000" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    entity (meta) data...
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://desk.draw.io/support/solutions/articles/16000042487" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>


### PR DESCRIPTION
After we created the business context diagram together last week, I tried to create the matching technical context diagram.

I created two versions, one that shows MediaWiki, and one that doesn't. I'm curious to hear which one you think makes more sense. I'm leaning towards the one that shows MW, but maybe that's too much detail for a context diagram?

Bug: [T271720](https://phabricator.wikimedia.org/T271720)