### PR TITLE
Don't check in unstaged file via commit hook

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,1 +1,0 @@
-git update-index --again

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 npm run fix
-git add .
+git update-index --again


### PR DESCRIPTION
To reproduce the problem on `main`:
* change some file and `git add` it
* create a new file and keep it untracked
* `git commit -m "Derp"`
* your new file is part of the commit even though it shouldn't

To verify that the hook still works on this branch:
* make a change in `README.md` for the linter to fix, e.g. pasting a [URL missing `<` and `>`](https://www.npmjs.com/package/remark-lint-no-literal-urls) somewhere
* `git add README.md`
* create a new file and keep it untracked
* `git commit -m 'Hurray'`
* marvel at technology because `README.md` is fixed but your untracked file stayed untracked

I also found a new unrelated problem: the linter only checks .md files in the root directory... will try to address that separately.