### PR TITLE
Add a table with all repo Action API modules

### DIFF
--- a/systems/WikibaseRepo/05-Building_Block_View.md
+++ b/systems/WikibaseRepo/05-Building_Block_View.md
@@ -4,9 +4,35 @@
 
 TBA
 
-## External Interfaces
+## Action API modules
 
-### Action API Edit Entity
+| Building Block                          | Responsibility                                                                              |
+| --------------------------------------- | ------------------------------------------------------------------------------------------- |
+| wbavailablebadges                       | Get available badge items                                                                   |
+| wbcreateclaim                           | Create Wikibase claims                                                                      |
+| wbcreateredirect                        | Create Entity redirects                                                                     |
+| [wbeditentity](#action-api-edit-entity) | Create a single new Wikibase entity and modifies it with serialised information             |
+| wbformatentities                        | Format entity IDs to HTML                                                                   |
+| wbformatvalue                           | Format DataValues                                                                           |
+| wbgetclaims                             | Get Wikibase claims                                                                         |
+| wbgetentities                           | Get the data for multiple Wikibase entities                                                 |
+| wblinktitles                            | Associate two pages on two different wikis with a Wikibase item                             |
+| [wbmergeitems](#action-api-merge-items) | Merge multiple items                                                                        |
+| wbparsevalue                            | Parse values using a ValueParser                                                            |
+| wbremoveclaims                          | Remove Wikibase claims                                                                      |
+| wbremovequalifiers                      | Remove a qualifier from a claim                                                             |
+| wbremovereferences                      | Remove one or more references of the same statement                                         |
+| wbsearchentities                        | Search for entities using labels and aliases                                                |
+| wbsetaliases                            | Set the aliases for a Wikibase entity                                                       |
+| wbsetclaim                              | Create or updates an entire Statement or Claim                                              |
+| wbsetclaimvalue                         | Set the value of a Wikibase claim                                                           |
+| wbsetdescription                        | Set a description for a single Wikibase entity                                              |
+| wbsetlabel                              | Set a label for a single Wikibase entity                                                    |
+| wbsetqualifier                          | Create a qualifier or sets the value of an existing one                                     |
+| wbsetreference                          | Create a reference or sets the value of an existing one                                     |
+| wbsetsitelink                           | Associate a page on a wiki with a Wikibase item or removes an already made such association |
+
+### [Action API Edit Entity](https://www.wikidata.org/w/api.php?action=help&modules=wbeditentity)
 
 ![Alt Text](./diagrams/05-api-wbeditentity.drawio.svg)
 
@@ -33,7 +59,7 @@ TBA
 | ApiErrorReporter                       | API response                  | A component for API modules that handles error reporting                                                                                                                                                     |
 | ResultBuilder                          | API response                  | Builder of MediaWiki ApiResult objects with various convenience functions for adding Wikibase concepts and result parts to results in a uniform way                                                          |
 
-### Action API Merge Items
+### [Action API Merge Items](https://www.wikidata.org/w/api.php?action=help&modules=wbmergeitems)
 
 ![Alt Text](./diagrams/05-api-wbmergeitems.drawio.svg)
 
@@ -44,6 +70,8 @@ TBA
 | [ItemMergeInteractor](#itemmergeinteractor) | Processing          | Performs an Item merge                                                                                                                              |
 | ApiErrorReporter                            | API response        | A component for API modules that handles error reporting                                                                                            |
 | ResultBuilder                               | API response        | Builder of MediaWiki ApiResult objects with various convenience functions for adding Wikibase concepts and result parts to results in a uniform way |
+
+## Special Pages
 
 ### Special Merge Items
 


### PR DESCRIPTION
This adds a table with the names and descriptions of all Action API modules in Wikibase repo, see [phabricator ticket T271450](https://phabricator.wikimedia.org/T271450).