### PR TITLE
Add maintenance scripts to Entity Change Notifications

### DIFF
--- a/systems/WikibaseClient/05-Building_Block_View.md
+++ b/systems/WikibaseClient/05-Building_Block_View.md
@@ -173,6 +173,8 @@ UsageAspectTransformer is only used outside of this block and perhaps shouldn't 
 | SubscriptionManager                                 | Persists infomation about pages being "subscribed" to updates for an Entity                            |
 | UsageTracker                                        | Persists infomation about the EntityUsages of a page                                                   |
 | UsageAspectTransformer                              | Transforms usage aspect based on a filter of aspects relevant in some context.                         |
+| populateEntityUsage                                 | Maintenance script for populating wbc_entity_usage based on the page_props table.                      |
+| updateSubscriptions                                 | Maintenance script for inserting subscriptions into wb_changes_subscription based on wbc_entity_usage. |
 
 ## Linked Site Page Changes
 

--- a/systems/WikibaseClient/diagrams/05-entitychangenotifications-usage.drawio.svg
+++ b/systems/WikibaseClient/diagrams/05-entitychangenotifications-usage.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="641px" height="406px" viewBox="-0.5 -0.5 641 406" content="&lt;mxfile host=&quot;1ebabf5c-2592-407d-b88c-bb7c0e53e3dc&quot; modified=&quot;2021-01-14T15:09:57.528Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;RBUk9fQw761dgkkUXSiM&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5VjZcpswFP0aP2bGLML2Y+olnU4zzYy7PAsQoFhIVBJe+vUVRrLBkJbUTjymLx7p3CvJnHMXxMCZptsHDrPkkYWIDOxhuB04s4Ftjyeu+i2AnQaGwxKIOQ5LyDoCS/wLadC45ThEouYoGSMSZ3UwYJSiQNYwyDnb1N0iRuqnZjBGDWAZQNJEf+BQJhr1gHs0fEQ4TszRljcpLSk03vpRRAJDtqlAznzgTDljshyl2ykiBXmGmHLd4gXr4Z9xRGWXBVPP30Q/d88oAvl0tb5bfXr8fmc75TZrSHL9yAPbI2rDDyFeq2FcDJe5LwKOM4kZNWZ1UMWjZdEjpIocrqYwzdSc+iKrePr8dO3pjnvS5M5IsUmwRMsMBsV8o6JNOSUyJWpmqWGECZkywvje24miyA4ChQvJ2QpVLKHne8ArVjAqdcRZwMz1ecMmu5rwNeISbSuQZvsBsRRJvlMuJviN8jr2HU/PN5VIMvmQVILI+EEdvPFh66O8aqAVfoXajttQ+5soMqChyWfGVnl2+xq41hU1sLvk1pxKLHfGIDJIjaUmjTqrautrzgAXXE+vZi18ITvugyBPcwKl4ufmKfdGV6S8c0H6ymGwQj2g+7QruG5HugE4n27QpSI91cvOn7v8X8qX+M/rV2d1L5FMXtdkmqEwzwgO+lnAgN01oy7A+ahzzxBZcUFpK2xURIynfShuE/CPr1vjC0gxbpdi3zkwjVteciGNc+WxgIT4yqnNw0dkhhqXn/69KDeSaAy6KXcAz5Fu8lrplhSuFippoJR9yJtT9t+1bZgrUoX9GZTwi/+sCpY4k1xkhQCN2sideCMHvk9PrhelQ7Gpkmu9FblWg9wnxAUWElHF4M2TO7auSW7zhn2vb2b7Yn3r5Hqja5LbvJuVza4HJeH0s9BbEqumx4+8e1vlU7kz/w0=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="641px" height="406px" viewBox="-0.5 -0.5 641 406" content="&lt;mxfile host=&quot;1a4eeac4-4425-4b7c-9e36-f223759438d0&quot; modified=&quot;2021-01-21T13:12:46.005Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) VSCodium/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;zRBGu08EbRlj_KbM0ICL&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5ZlLc5swEIB/jY+ZMWBhfEzsJJ1OM82M+zgLEKBYSKoQfvTXVxhhAyIpaZx4TE+WdlfI/la7q8UjZ55u7wXkyQMLERnZ43A7chYj27bGNlAfhWRXSuyZVQpigUNtdBQs8W9UrdTSHIcoaxhKxojEvCkMGKUokA0ZFIJtmmYRI81dOYyRIVgGkJjSnziUiZa6YHJUfEI4TqqtLXdWalJYWeufkiUwZJuayLkdOXPBmCxH6XaOSEGvAlOuu3tGe/hmAlHZZ8Hc9TfRr90TikA+X62vVp8fflzZTvmYNSS5/skj2yXqgTchXqthXAyXuZ8FAnOJGa3UaqOaRceiB0gVHKGmMOVqTv2M1yx90V7bfuIemtxVrtgkWKIlh0Ex36jjpowSmRI1s9QwwoTMGWFib+1EUWQHgZJnUrAVqmlC13eBW6xgVOoTZ4Fqrvcbm3Q18DUSEm1rIk37HrEUSbFTJlrrVZ7XZ99x9XxTO0ljLUtqh6iyg/rwxodHH92rBtrDr/C2MzG8/T0rIsDwyRfGVjm/fB9MrDP6wO4TW7dUYrmrFBmHtNI0XKP2quuGGjNgAs7nLzMXPhMd10GQpzmBUvG5eOTu9IzIeyekbwIGKzQA3O2qMJn0xA3A23GDPhnpsZl2Xq7yf0lf2X+ev3p79xTB5PYNpgUKc05wMMwEBuy+EXUC5tPeNSPjRYPSldhoFjGRDiG5zcA/Xre8E7jC63bFvnJgGndcciGNc2VxBwnxlVGXhY/IAhnNz/AuykYQeaCf5w7Ct7hu9lrXLSlc3amggVIOIW7a9D+0bFQtUo3+Akr41X9SCSt7I1xkhQBNu+DO3KkDP6YmN5PSIdnU4VrvBdcy4D4ikeFMIqoIXjxczzonXLPDvtad2T5ZXzpcd3pOuGZvVha7AaSE9muhjwVrdmGc8eLQFtdGhUFtXDVW+jLZ4t0uYF6AuguY76mGZHyGrrb/HfwEXa1lNj45D5s466+wzQN8aqDODSQ4pmocKKbqhlL1tieF7I7fD7KaHv+a2Otq//A4t38A&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="410" y="80" width="100" height="60" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
@@ -277,6 +277,24 @@
                     Lookups
                 </text>
             </switch>
+        </g>
+        <rect x="410" y="240" width="100" height="55" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="15px">
+            <text x="459.5" y="264.5">
+                populate
+            </text>
+            <text x="459.5" y="282.5">
+                EntityUsage
+            </text>
+        </g>
+        <rect x="410" y="320" width="100" height="55" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="15px">
+            <text x="459.5" y="344.5">
+                update
+            </text>
+            <text x="459.5" y="362.5">
+                Subscriptions
+            </text>
         </g>
     </g>
     <switch>


### PR DESCRIPTION
This adds two maintenance scripts to the "Usage" subsection of the
building blocks view for Entity Change Notifications.

Bug: [T272971](https://phabricator.wikimedia.org/T272971)