### PR TITLE
Create a legend for all diagrams

### DIFF
--- a/diagrams/legend.drawio.svg
+++ b/diagrams/legend.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="617px" height="305px" viewBox="-0.5 -0.5 617 305" content="&lt;mxfile host=&quot;a0506eac-8fb1-4a91-8507-f0bc3776bc03&quot; modified=&quot;2021-01-28T15:15:40.281Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; version=&quot;13.10.0&quot; etag=&quot;J1W9sztDZMGrTABZcX_e&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;zM_JA1C9UGHOPTVELOfY&quot; name=&quot;Page-1&quot;&gt;7VlNj9owEP01XCuTEDZ7XOi2PXQv3Up7duJJYuHYyDEE+utrJzbkw1StRHKhi7Qkz+Ov92bssVmE2/L0VeJ98SYIsEWAyGkRfl4EQRwH+r8Bzi2wQmEL5JKSFlpegXf6CyyILHqgBKqeoRKCKbrvg6ngHFLVw7CUou6bZYL1e93jHEbAe4rZGP2gRBV2WhG64t+A5oXreYlsSYmdsQWqAhNRd6DwdRFupRCqfSpPW2CGO8dLW+/LjdLLwCRw9TcVrBBHzA52bt8hB07s6NTZTVnBSTe4KVTJNLDUj5WSYgdbwYTUCBdcW24yytgAwozmXL+mekig8c0RpKKazBdbUFJCTDebuqAK3vc4NX3W2nM0JsWBEzCjRaZ5wZV1h+XavdtB2rmb1uF0k47lhWTtnCBKUPKsTVwFtGqrWMdcW5nqq8rPFio6AocWw9av8kvDV+r1g2Xfr0Q4UmKkQZ8LH1sdeUZUdZRZBGGWZUGajmTUJWSdrCNT4x58Oj8/O37HhMYeQoM7ELqal1BYkgiefIQ+r59CPBWhq/kIjeYlVNMZk5WP0DhIwvVUhMbzEbqel9DNi/ncWrkn4PJC0gxcPs28fEbmY+06ePvnc9oB+y5vCCai3rNzTUV9/C/UN5mDS3qGREf+DGLEJULbLUJeLgd6XCz7mUK4YTgBthGSgBz01pbgdJc3ox6UFkLSX7ot7BxlmM0oYTyp0o5Fef7DMo2u0HfIDBJGndSINdgUfhDOuD88j/zgZwEaYKKGSpkHODbnAJGZnoyHiEzVem5Nql7uNcN6loHuCMGn/JM1ShmuKlNLGoCbDk0imZnIvX+WaqW4U466uo+qwV+kUav1RLK6Q1dH15fmZCYOeydmcqCMaOc2j0ykuxvaVs2Q9Yj1ea1xjQqX5ktCpQ0qmlBG1dkaUe685FwpKB9Wa08ER2gqrZderfU5umG7G4TAj1QKXjYhi+oCGqm7eiFGj/qU3o3nNyAUf9AdfVg1PenldGqOT/dGTW66ScRBtgF7kctGpuYp7USod4lul2Ccqr68RtkEV/AD9sIYVdYjbvWoRKfSltGm7cd0DF+uPJ1jjC8bXnmK99WBYQVOtd4K31vDVYGNE5R4Z/yiMfq/UPtSrek25fHtxmawB1fdTOtmBLZKunC+rgLDHf3Sml0WXAMJtEYEqlTSRBP+oPL7TlzTyT/zXUwWp+C/LUziaBWhiQ4vM94WLseXMX/aK9s86Pb+6OLKhA0XTeZUcxMcKDET/nj7/PqogeJT9V6Bol+vv500ZZ0foMLX3w==&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="617px" height="345px" viewBox="-0.5 -0.5 617 345" content="&lt;mxfile host=&quot;a0506eac-8fb1-4a91-8507-f0bc3776bc03&quot; modified=&quot;2021-01-28T15:31:21.897Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; version=&quot;13.10.0&quot; etag=&quot;K6StLrV-Ivkot708Irfl&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;zM_JA1C9UGHOPTVELOfY&quot; name=&quot;Page-1&quot;&gt;7VnLjqM4FP2abEsGAkUtK+n0zKJrMZXW1NrABawYOzLOq79+bLATHs6oRwpsMolUBcfXr3Puta+dRbCuzn8IvC8/eAZ04aPsvAi+LXw/jn31VwOXFliioAUKQbIW8m7AlvwCAyKDHkgGdc9Qck4l2ffBlDMGqexhWAh+6pvlnPZ73eMCRsA2xXSMfpFMlmZaIbrhfwIpStuzh0xJha2xAeoSZ/zUgYLNIlgLzmX7VJ3XQDV3lpe23vc7pdeBCWDydyoYIY6YHszcfkABLDOjkxc7ZQln1eCqlBVVgKceayn4DtaccqEQxpmyXOWE0gGEKSmYek3VkEDhqyMISRSZ76agIlmmu1mdSiJhu8ep7vOkPEdhgh9YBnq0SDfPmTTu4EX23QzSzF23Due7dHhXkpVzAq9AiosysRXQsq1iHNPKdLqp/GagsiNwYDBs/Kq4NnyjXj0Y9t1KBCMlRhr0uXCx1ZFnRFVHmYUf5Hnup+lIRlWSRUkU6hqP4NMSeLH8jgmNHYT6DyB0OS+h4GUhvLoIfYteAzwVocv5CA3nJVTRGWdLF6GxnwTRVITG8xEazUvo6l1/763cE3DpWj6n4vJ15uUz1F9j18Hbj8tpB+zbvMGfiPpoPurj/0J9kznYpGdIdOjOIEZcIrReI+TkcqDH1bKfKQQrihOgKy4yEIPe2hKc7opm1IPSkgvyS7WFraMMsxnJtSfVyrEIKz4N0+gG/YBcI0HYSY1og03hB8GM+8PbyA9+lqAAyk9QS/0Ax+YcwHPdk/YQnsuTmluTqld7xbCapa86QvBSvBijlOK61rWEBpjuUCeSuY7cx2epRooH5ajLx6jq/0YatYwmktUeujq6vjcnM37YWzGTA6GZcm79SHm6u6Nt3QxZjVid1xrXqHGl/wmolUFNEkKJvBgjwqyXXGoJ1dNq7YjgEE2ltefUWp2jG7a7QQjsSARnVROy6FRCI3VXL0TJUZ3Su/H8ARnBX2RHnlZNR3o5nZrj071Wk+luEn4QbcBe5TKRqXhKOxHqXKLbJRinsi+vVjbBNXzCnmuj2njEvR4l71RaU9K0/ZyO4cqVp3OM8WXDhqV4Xx8olmBV663wvTVcllg7QYV32i8ao/8XaleqNd2mPL7dWA324Lqbad2NwFZJG863VWC4o19bM8uCbSCB1iiDOhUkUYQ/qfyuE9d08s98F5PHKbhvC5M4XIZoosPLjLeF3vgy5t/2yjYPur8/2rjSYcN4kzmdmA4OlOgJf3182zxroLhUnS5QZr4X8hLsge++s4g279/HNxR585kmgGa8BPLGt0A6fra38Nia2Onkiz9BVAk/q6e/dd3t9rMt/usAzbS2II5EH/MRyPTlWQNmwo1Fvd5+a2zKOj/YBpt/AA==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="0" y="0" width="90" height="30" fill="none" stroke="none" pointer-events="all"/>
@@ -18,18 +18,18 @@
                 </text>
             </switch>
         </g>
-        <rect x="16" y="40" width="80" height="20" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
-        <rect x="16" y="80" width="80" height="20" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
-        <rect x="16" y="120" width="80" height="20" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
-        <rect x="16" y="160" width="80" height="20" fill="#bababa" stroke="none" pointer-events="all"/>
-        <rect x="16" y="200" width="80" height="20" fill="#f5f5f5" stroke="#bababa" stroke-width="2" pointer-events="all"/>
-        <rect x="16" y="280" width="80" height="20" rx="3" ry="3" fill="none" stroke="#000000" stroke-width="2" transform="translate(2,3)" opacity="0.25"/>
-        <rect x="16" y="280" width="80" height="20" rx="3" ry="3" fill="none" stroke="#00cc00" stroke-width="2" pointer-events="all"/>
-        <rect x="116" y="40" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="16" y="80" width="80" height="20" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <rect x="16" y="120" width="80" height="20" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
+        <rect x="16" y="160" width="80" height="20" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <rect x="16" y="200" width="80" height="20" fill="#bababa" stroke="none" pointer-events="all"/>
+        <rect x="16" y="240" width="80" height="20" fill="#f5f5f5" stroke="#bababa" stroke-width="2" pointer-events="all"/>
+        <rect x="16" y="320" width="80" height="20" rx="3" ry="3" fill="none" stroke="#000000" stroke-width="2" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="16" y="320" width="80" height="20" rx="3" ry="3" fill="none" stroke="#00cc00" stroke-width="2" pointer-events="all"/>
+        <rect x="116" y="80" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 50px; margin-left: 118px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 90px; margin-left: 118px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
                             <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 The lowest level of a software component, e.g. a class or an interface
@@ -37,25 +37,8 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="118" y="54" fill="#000000" font-family="Helvetica" font-size="14px">
-                    The lowest level of a software component, e.g. a class or an inter...
-                </text>
-            </switch>
-        </g>
-        <rect x="116" y="80" width="500" height="20" fill="none" stroke="none" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 498px; height: 1px; padding-top: 90px; margin-left: 118px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                A group of building block software components with the same responsibility within a system
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
                 <text x="118" y="94" fill="#000000" font-family="Helvetica" font-size="14px">
-                    A group of building block software components with the same responsibil...
+                    The lowest level of a software component, e.g. a class or an inter...
                 </text>
             </switch>
         </g>
@@ -66,13 +49,13 @@
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 498px; height: 1px; padding-top: 130px; margin-left: 118px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
                             <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                A context or an environment where a system lives, e.g. MediaWiki
+                                A group of building block software components with the same responsibility within a system
                             </div>
                         </div>
                     </div>
                 </foreignObject>
                 <text x="118" y="134" fill="#000000" font-family="Helvetica" font-size="14px">
-                    A context or an environment where a system lives, e.g. MediaWiki
+                    A group of building block software components with the same responsibil...
                 </text>
             </switch>
         </g>
@@ -83,21 +66,38 @@
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 498px; height: 1px; padding-top: 170px; margin-left: 118px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
                             <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                A neighbouring system with which the software component interacts, e.g. WikibaseRepo is a neighbouring system to WikibaseClient
+                                A context or an environment where a system lives, e.g. MediaWiki
                             </div>
                         </div>
                     </div>
                 </foreignObject>
                 <text x="118" y="174" fill="#000000" font-family="Helvetica" font-size="14px">
+                    A context or an environment where a system lives, e.g. MediaWiki
+                </text>
+            </switch>
+        </g>
+        <rect x="116" y="200" width="500" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 498px; height: 1px; padding-top: 210px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                A neighbouring system with which the software component interacts, e.g. WikibaseRepo is a neighbouring system to WikibaseClient
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="214" fill="#000000" font-family="Helvetica" font-size="14px">
                     A neighbouring system with which the software component interacts, e.g....
                 </text>
             </switch>
         </g>
-        <rect x="116" y="280" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="116" y="320" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 290px; margin-left: 118px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 330px; margin-left: 118px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
                             <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 Encapsulates a group of components that make up a system
@@ -105,29 +105,11 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="118" y="294" fill="#000000" font-family="Helvetica" font-size="14px">
+                <text x="118" y="334" fill="#000000" font-family="Helvetica" font-size="14px">
                     Encapsulates a group of components that make up a system
                 </text>
             </switch>
         </g>
-        <rect x="116" y="200" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 210px; margin-left: 118px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                Building blocks of a neighbouring system that interact with building blocks of the system being described
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="118" y="214" fill="#000000" font-family="Helvetica" font-size="14px">
-                    Building blocks of a neighbouring system that interact with buildi...
-                </text>
-            </switch>
-        </g>
-        <rect x="16" y="240" width="80" height="20" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
         <rect x="116" y="240" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -135,13 +117,49 @@
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 250px; margin-left: 118px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
                             <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                A neighbouring system or a software component that is not owned by WMDE
+                                Building blocks of a neighbouring system that interact with building blocks of the system being described
                             </div>
                         </div>
                     </div>
                 </foreignObject>
                 <text x="118" y="254" fill="#000000" font-family="Helvetica" font-size="14px">
+                    Building blocks of a neighbouring system that interact with buildi...
+                </text>
+            </switch>
+        </g>
+        <rect x="16" y="280" width="80" height="20" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+        <rect x="116" y="280" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 290px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                A neighbouring system or a software component that is not owned by WMDE
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="294" fill="#000000" font-family="Helvetica" font-size="14px">
                     A neighbouring system or a software component that is not owned by...
+                </text>
+            </switch>
+        </g>
+        <rect x="16" y="40" width="80" height="20" fill="#1ba1e2" stroke="#006eaf" pointer-events="all"/>
+        <rect x="116" y="40" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 50px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                A Software System, e.g. Termbox V2 SSR, Query Service etc.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="54" fill="#000000" font-family="Helvetica" font-size="14px">
+                    A Software System, e.g. Termbox V2 SSR, Query Service etc.
                 </text>
             </switch>
         </g>

--- a/diagrams/legend.drawio.svg
+++ b/diagrams/legend.drawio.svg
@@ -1,0 +1,157 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="617px" height="305px" viewBox="-0.5 -0.5 617 305" content="&lt;mxfile host=&quot;a0506eac-8fb1-4a91-8507-f0bc3776bc03&quot; modified=&quot;2021-01-28T15:15:40.281Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; version=&quot;13.10.0&quot; etag=&quot;J1W9sztDZMGrTABZcX_e&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;zM_JA1C9UGHOPTVELOfY&quot; name=&quot;Page-1&quot;&gt;7VlNj9owEP01XCuTEDZ7XOi2PXQv3Up7duJJYuHYyDEE+utrJzbkw1StRHKhi7Qkz+Ov92bssVmE2/L0VeJ98SYIsEWAyGkRfl4EQRwH+r8Bzi2wQmEL5JKSFlpegXf6CyyILHqgBKqeoRKCKbrvg6ngHFLVw7CUou6bZYL1e93jHEbAe4rZGP2gRBV2WhG64t+A5oXreYlsSYmdsQWqAhNRd6DwdRFupRCqfSpPW2CGO8dLW+/LjdLLwCRw9TcVrBBHzA52bt8hB07s6NTZTVnBSTe4KVTJNLDUj5WSYgdbwYTUCBdcW24yytgAwozmXL+mekig8c0RpKKazBdbUFJCTDebuqAK3vc4NX3W2nM0JsWBEzCjRaZ5wZV1h+XavdtB2rmb1uF0k47lhWTtnCBKUPKsTVwFtGqrWMdcW5nqq8rPFio6AocWw9av8kvDV+r1g2Xfr0Q4UmKkQZ8LH1sdeUZUdZRZBGGWZUGajmTUJWSdrCNT4x58Oj8/O37HhMYeQoM7ELqal1BYkgiefIQ+r59CPBWhq/kIjeYlVNMZk5WP0DhIwvVUhMbzEbqel9DNi/ncWrkn4PJC0gxcPs28fEbmY+06ePvnc9oB+y5vCCai3rNzTUV9/C/UN5mDS3qGREf+DGLEJULbLUJeLgd6XCz7mUK4YTgBthGSgBz01pbgdJc3ox6UFkLSX7ot7BxlmM0oYTyp0o5Fef7DMo2u0HfIDBJGndSINdgUfhDOuD88j/zgZwEaYKKGSpkHODbnAJGZnoyHiEzVem5Nql7uNcN6loHuCMGn/JM1ShmuKlNLGoCbDk0imZnIvX+WaqW4U466uo+qwV+kUav1RLK6Q1dH15fmZCYOeydmcqCMaOc2j0ykuxvaVs2Q9Yj1ea1xjQqX5ktCpQ0qmlBG1dkaUe685FwpKB9Wa08ER2gqrZderfU5umG7G4TAj1QKXjYhi+oCGqm7eiFGj/qU3o3nNyAUf9AdfVg1PenldGqOT/dGTW66ScRBtgF7kctGpuYp7USod4lul2Ccqr68RtkEV/AD9sIYVdYjbvWoRKfSltGm7cd0DF+uPJ1jjC8bXnmK99WBYQVOtd4K31vDVYGNE5R4Z/yiMfq/UPtSrek25fHtxmawB1fdTOtmBLZKunC+rgLDHf3Sml0WXAMJtEYEqlTSRBP+oPL7TlzTyT/zXUwWp+C/LUziaBWhiQ4vM94WLseXMX/aK9s86Pb+6OLKhA0XTeZUcxMcKDET/nj7/PqogeJT9V6Bol+vv500ZZ0foMLX3w==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <rect x="0" y="0" width="90" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 15px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Legend
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="45" y="20" fill="#000000" font-family="Helvetica" font-size="16px" text-anchor="middle" font-weight="bold">
+                    Legend
+                </text>
+            </switch>
+        </g>
+        <rect x="16" y="40" width="80" height="20" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <rect x="16" y="80" width="80" height="20" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
+        <rect x="16" y="120" width="80" height="20" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <rect x="16" y="160" width="80" height="20" fill="#bababa" stroke="none" pointer-events="all"/>
+        <rect x="16" y="200" width="80" height="20" fill="#f5f5f5" stroke="#bababa" stroke-width="2" pointer-events="all"/>
+        <rect x="16" y="280" width="80" height="20" rx="3" ry="3" fill="none" stroke="#000000" stroke-width="2" transform="translate(2,3)" opacity="0.25"/>
+        <rect x="16" y="280" width="80" height="20" rx="3" ry="3" fill="none" stroke="#00cc00" stroke-width="2" pointer-events="all"/>
+        <rect x="116" y="40" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 50px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                The lowest level of a software component, e.g. a class or an interface
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="54" fill="#000000" font-family="Helvetica" font-size="14px">
+                    The lowest level of a software component, e.g. a class or an inter...
+                </text>
+            </switch>
+        </g>
+        <rect x="116" y="80" width="500" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 498px; height: 1px; padding-top: 90px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                A group of building block software components with the same responsibility within a system
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="94" fill="#000000" font-family="Helvetica" font-size="14px">
+                    A group of building block software components with the same responsibil...
+                </text>
+            </switch>
+        </g>
+        <rect x="116" y="120" width="500" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 498px; height: 1px; padding-top: 130px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                A context or an environment where a system lives, e.g. MediaWiki
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="134" fill="#000000" font-family="Helvetica" font-size="14px">
+                    A context or an environment where a system lives, e.g. MediaWiki
+                </text>
+            </switch>
+        </g>
+        <rect x="116" y="160" width="500" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 498px; height: 1px; padding-top: 170px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                A neighbouring system with which the software component interacts, e.g. WikibaseRepo is a neighbouring system to WikibaseClient
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="174" fill="#000000" font-family="Helvetica" font-size="14px">
+                    A neighbouring system with which the software component interacts, e.g....
+                </text>
+            </switch>
+        </g>
+        <rect x="116" y="280" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 290px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Encapsulates a group of components that make up a system
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="294" fill="#000000" font-family="Helvetica" font-size="14px">
+                    Encapsulates a group of components that make up a system
+                </text>
+            </switch>
+        </g>
+        <rect x="116" y="200" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 210px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Building blocks of a neighbouring system that interact with building blocks of the system being described
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="214" fill="#000000" font-family="Helvetica" font-size="14px">
+                    Building blocks of a neighbouring system that interact with buildi...
+                </text>
+            </switch>
+        </g>
+        <rect x="16" y="240" width="80" height="20" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+        <rect x="116" y="240" width="460" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 458px; height: 1px; padding-top: 250px; margin-left: 118px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                A neighbouring system or a software component that is not owned by WMDE
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="118" y="254" fill="#000000" font-family="Helvetica" font-size="14px">
+                    A neighbouring system or a software component that is not owned by...
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://desk.draw.io/support/solutions/articles/16000042487" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/systems/WikibaseClient/05-Building_Block_View.md
+++ b/systems/WikibaseClient/05-Building_Block_View.md
@@ -1,5 +1,7 @@
 # Building Block View
 
+![Legend](../../diagrams/legend.drawio.svg)
+
 ## Whitebox Overall System
 
 ![Alt Text](./diagrams/05-building-blocks.drawio.svg)

--- a/systems/WikibaseClient/diagrams/05-api-description.drawio.svg
+++ b/systems/WikibaseClient/diagrams/05-api-description.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="531px" height="401px" viewBox="-0.5 -0.5 531 401" content="&lt;mxfile host=&quot;2711111a-f102-4711-a829-552d40579477&quot; modified=&quot;2021-01-12T17:26:39.432Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;ac_kdEIJSCntK9KlSXv9&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5Zhdk5owFIZ/DTPthTN8Rrncxe22HZ1p15nudYQgqZHDhiDaX98giYJoa6uu/bgyeU/CIefJyQkaTrBYPXKcJWOICDNsM1oZztCwbct0XflTKetaGZhmLcw4jdSgnTCh34ieqdSCRiRvDRQATNCsLYaQpiQULQ1zDmV7WAys7TXDM9IRJiFmXfWZRiJRKvLcneE9obNEu7aQX1sWWI9WS8kTHEHZkJwHwwk4gKhbi1VAWBU9HZh63rsj1u2bcZKKUyYEaFrGL+uvJPaKYL7szT+Ov/Qs9ZglZoVa8ghgXsjw1i8t1joUHIo0ItXDTMO5LxMqyCTDYWUtJXypJWLBZM+SzZgyFgADvpnrECvySF/queAwJw2Lj/oORtUMSIXibw10X3k3u2vV7024IKuGpNb+SGBBBF/LIcra11tK7UTbVf2ywdVTWtJCqkSs9tJs++xdtGVDBfxXgt/vBN+wEZN+7yO6lM1Z1XwiGYxoOidcG6dc27Qi3TdmdND9BBbOszp3YrqqAO/Ti+PYDsND9CI0Rd4+Pe8K9HynTc/pd+n5B+D5F2DnHKVUrbIVafRSgDb08k087uQAy8tWO6PGlHGQIIbyfAs5zQSFtAv47tOHBuPa3xHI5+SnzM5B5B4iPLCnDkJbf2dBRHspuM2sV0lB98fJ9rsU7zL6uSB8LbOIHEvHC7h5MyYRxc90TuWQ6caXGTKc529PPAPO2R4nHACXOKH9E7ZH/1rbw+tsj03umU8kzyCt4v1v1UPfvGU9RKdUvuHuZKwvJX93AeywOUDweHK4tyuA3WtKAGlMZwXHddX64zLjrFB79i0zY3Cl24Zhu5gxKEcgv24mCXBRpddrXC5Orh4XpXYoQQ5SQxeA5l8PWgw8JP8LNNe7HjTZ3X1sb2yN/yych+8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="531px" height="401px" viewBox="-0.5 -0.5 531 401" content="&lt;mxfile host=&quot;cee0f7de-ca85-4223-b1eb-b8d82ca35695&quot; modified=&quot;2021-02-02T10:50:44.414Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;iAti-6heR99eQLIYavQM&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5Vffb5swEP5rkLaHSPymPLa06zYl0tZI67MDR/DicNSYQPbXzwSTQEi2bEsUrX2J7O/OPt9999lBs4Jl9chJlkwwAqaZelRp1r1mmr5hyt8aWDeAbfgNMOc0aiBjB0zpD1CgrtCCRpD3HAUiEzTrgyGmKYSihxHOsey7xcj6UTMyhwEwDQkbos80EolCXcfeGT4CnSdtaMNVCS5J661SyRMSYdmBrAfNCjiiaEbLKgBWF68tTLPuwxHr9mQcUnHKgsCdlfHL+jvEThEsVqPF58m3kaG2WRFWqJTHiItClrc5tFi3peBYpBHUm+madVcmVMA0I2FtLSX3EkvEksmZIYcxZSxAhnyz1gIjcsCTeC44LqBj8V3PIm69AlOh+Ddu2rmKrg9zbc8NXEDVgVTuj4BLEHwtXZTVa1tKdaJpq3nZ4dVRWNKjVIFE9dJ8u/eu2nKgCv4nxfcGxddMl8m4dxFdyeG8Hj5BhmOaLoC3xhlvbS0iw3dWDKj7DVkkzxrtxLSqCd5nL45jMwwPsRe5M9fZZ8+5AHu+1WfP8obs+QfI88/Anf1rljqFdl+KWs2b7Ef5phy30sFwsmpnbFm6zejXAvhalh+O8XiGMO8mEFHyTBdUusw2sfSQkTx/f2Lz/IvuT+icc0jb7zfHVrFdaXuXkrYzaI/bL58k8AR5hmld79d1kfr6NS9S95Qr8x7ykNNMUEyb1+wN35yefb2bc/i+BZjGdF5wUnPz2pThmNdUxs1RZdR5/v0Dopk2YQzLMcq/xdMEuajl1dFPs/1/+3rss3ZIIAdZc89Amn850mLkIbwV0mzncqTJ6e4rbWPrfOtaDz8B&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="190" y="130" width="150" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
@@ -35,27 +35,6 @@
                 </foreignObject>
                 <text x="455" y="310" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     RepoLinker&#xa;
-                </text>
-            </switch>
-        </g>
-        <rect x="90" y="0" width="150" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 55px; margin-left: 91px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                <font style="font-size: 15px">
-                                    prop=description
-                                    <br/>
-                                    API
-                                </font>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="165" y="59" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    prop=description...
                 </text>
             </switch>
         </g>

--- a/systems/WikibaseClient/diagrams/05-api-entityusage.drawio.svg
+++ b/systems/WikibaseClient/diagrams/05-api-entityusage.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="351px" height="351px" viewBox="-0.5 -0.5 351 351" content="&lt;mxfile host=&quot;c8db6b7d-67ca-4505-b243-781b4d7c1215&quot; modified=&quot;2021-01-12T17:23:15.705Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;Umt2wg3XkKtQRQ3n1LeW&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;3VZNc5swEP01zLQHz/CNOTo0ddOpp60905wFLEa1jIgQNvTXV4Bkg7FTt3Fy6InV211W2vdWoFnBtpozlKcLGgPRTD2uNOuDZpqGbtvi0SB1h0x1vQPWDMcy6Ais8C9QmRItcQzFIJBTSjjOh2BEswwiPsAQY3Q/DEsoGVbN0RpGwCpCZIw+4pinEnUd++j4BHidqtKG63eeLVLR8ihFimK670HWvWYFjFLeWdsqANJ0TzWmy/t4wXvYGYOMX5MQuOE+eap/QuKUwWY32Xxe/JgY8jU7REp55DlwATxkCRVHwDSTu+e16gmjZRZD81Zds+72KeawylHUePdCBQJL+ZaIlSHMBBMSUEJZm2uBETvgCbzgjG6g5/Fdz0Juk0EzLoVgTNVaVtfHh1YHAMah6kGyCXOgW+CsFiHS6yltSUmatlzvewQ7EksH3EoQSVGtD+8+tl0YsvN/w4I3YkEzXSLq3sV4J8x1Yy4hp19wtgGmnCFTPoWI8r2MEXV/IAsVeTdECa4agk/ZS5LEjKJz7MVu6Dqn7DmvwJ5vDdmzvDF7/hny/BtwZ11kqTnloNPuU0mVY1K0/ZiJAMPJq6NT0ZQzmjd8hKItmNdl0VxKI4q/LscYwQVvMxvj2ezZt4eeRrr9XhDJS+ZbTPc0ts8pZGqGluse6t10hA+T+SYjbD8/rP+qglmOv5fAajGFV7KvMuaQAUOcsn7q6U1wgx2+W0CM0SPeYBEStrX0iKCieH/l9fMSZV1x99xAWVP/CmV5r6UsZ6Ssdmz1JRQ5zZp+/1+fYl9/w0+xWB5/tlpf75/Vuv8N&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="351px" height="351px" viewBox="-0.5 -0.5 351 351" content="&lt;mxfile host=&quot;ae6f9b48-f102-497e-9d34-a505ad224fea&quot; modified=&quot;2021-02-02T10:50:50.045Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;DzWr1wozX8aVPUx-utEE&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;3VZNc5swEP01zLQHz/BhIBwdkrrp1NPWnknOMlpAtYyIEAb66yuMZMCkjTt1eujFs3q7q9XuexI2nHBfLznK0xXDQA3bxLXh3Bm2HVi2/G2BpgPmVtABCSe4g6we2JAfoEBToSXBUIwCBWNUkHwMRizLIBIjDHHOqnFYzOi4ao4SmACbCNEp+kSwSBXqufPe8RFIkurSlqca3CMdrVopUoRZNYCce8MJOWOis/Z1CLQdnh5Ml/fhF97TyThk4pKE0NtW8XPzHWK3DHeH2e7T6nFmqW0OiJaq5SUICTxkMZMtEJap04tGz4SzMsPQ7moazm2VEgGbHEWtt5IikFgq9lSuLGnGhNKQUcaPuQ5Y2AVf4oXgbAcDT+D5DvLaDJYJJQTrRq9VdXPatG4AuIB6AKkhLIHtQfBGhiivr7WlJGnP1boaEOwqLB1xq0CkRJWc9u7HLg01+T9hwZ+wYNgelXVvMTlIM2nNNeTsM8l2wLVzy7VPI7L8IGNC3StkoSLvLlFM6pbgc/biOLaj6CX2sLf13HP23DdgL3DG7Dn+lL3gBfKCK3A3/z1Lg0F7z2V7rY/dz4rjOBYywHLzundqlhY5+VYCb+T4Ycrsl/UU0xlLyIAjwfgw9VwCVzjhuxVggp7IjsiQ7bGWGVFUFO8v1N3fPBkXiO4KuroJxro6Xfbhq+C/1avgTpS1+PoggTUUOcvaef9fb3Bg/sM3WC77r+zRN/iv4tz/BA==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="0" y="130" width="150" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
@@ -35,31 +35,6 @@
                 </foreignObject>
                 <text x="265" y="310" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     RepoLinker&#xa;
-                </text>
-            </switch>
-        </g>
-        <rect x="0" y="0" width="150" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 55px; margin-left: 1px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                <font style="font-size: 15px">
-                                    prop=wbentityusage
-                                    <br/>
-                                    OR
-                                    <br/>
-                                    list=wblistentityusage
-                                    <br/>
-                                    API
-                                </font>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="75" y="59" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    prop=wbentityusage...
                 </text>
             </switch>
         </g>

--- a/systems/WikibaseClient/diagrams/05-api-metawikibase.drawio.svg
+++ b/systems/WikibaseClient/diagrams/05-api-metawikibase.drawio.svg
@@ -1,25 +1,6 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="331px" height="351px" viewBox="-0.5 -0.5 331 351" content="&lt;mxfile host=&quot;66355680-7264-4384-bdc4-97d40f5f0f1a&quot; modified=&quot;2021-01-12T17:13:00.656Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;WcgB8I1cMmpaCBvVMIS9&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5VZdj5swEPw1SO1DJMAJSR4Tek2v0kmtIvWeDV7AjcGcMQH667sEk8CRu/b6carUJ69n12t7ZnBiET+td4rmyZ1kICzXZrVF3lmu69jzOQ4t0nTIyrY7IFacmaILsOffoF9p0JIzKEaFWkqheT4GQ5llEOoRRpWS1bgskmK8a05jmAD7kIopes+ZTgzqLeaXxAfgcdJv7XjrLpPSvtpcpUgok9UAIjcW8ZWUuovS2gfRstcT0617/0T2fDIFmf6ZBb4XVNFD8xWiRekfjrPDx7svM3ONIxWluXEKmmJU8QMPaAGW6wlsvw0URnEb4UjTHIMsKNph8+nWXFA3PW1VwjXscxq28wqtgXWJTgXOHAxpkXdiRbwGPN424kL4Ukh1Wk7YAlZsjnihlTzAILNyA+J57QqZaWMXZ9HPzQHsKTWGrSMoDfUAMlTtQOK9VYMlJrskpkvTC2vm1cAGPZaMHGBAaqwXn3tfxMHA6PMCrbyJVr04jB9H/HsPZeuqEymz4sTSBgucRV5fkr2em5x/LkE124HaeL5Tz7Piv7/NmztgnN6jrbCkc5YdCloUb4cW+9XuTx38z/oyiiI3DK/5knmBt3gNX67W/5wvHWdizB1oBG6zSOIzyGU2EULJMmMtxUgK2f5AlkcqgIPvw/KaCmtvSehjFVZ/43Wwxyq486kKhLyuCsvnn4fui9iD1jyLi41StLn6tv8nn5E7FpAspwKur+i3frl8OL38yJ9yg/9K5OY7&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="331px" height="351px" viewBox="-0.5 -0.5 331 351" content="&lt;mxfile host=&quot;4075172c-a3f9-42a7-b18c-45cd5bc423b9&quot; modified=&quot;2021-02-02T10:50:55.836Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;gJyqpeOASHPVvpvqyQjF&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5VXBbpwwEP0apPawEtgLhOMuTbettIdqpebsxQO4azAxZoF+fQ2YACFpm6rNJRfwvBnPjP3egIXDrDlIUqRHQYFbyKaNhT9YCAUO0s8OaAdg6wQDkEhGB8iZgBP7AQa0DVoxCuUiUAnBFSuWYCTyHCK1wIiUol6GxYIvqxYkgRVwighfo3eMqtSgnrudHJ+AJelY2vHMATMyRpujlCmhop5B+NbCoRRCDausCYF3lzdezLDv4zPeh84k5OpPNoTeuY7v2+8Qu1V4uW4uX47fNt6Q5Up4ZU5sIY/rfHvKrl3TqjVX4d1XXaf7WORqU/ZE7XSA4xbN5NSrpHvvCva1AtnuSQljQt1Zn3OI+Cdl3h2BMnLHLkyHnPtadsRJWb4f05/l32d/rnG0SInqlCk4FSTq7FpPgQ5KVca15eglKYtBmDFrgHa1Geeh4EL223EcxyiKNF4qKS4w81Dv7Lme6daMhuOOtmnAXsvAKOMKUkEzg4wsDiAyULLVIcZ7E5gs7ShiY9czyY9YulC7AYkZs+Qh9yREvTBafIEuHWclzAMoDXzOY6FHi4l8RYQUVU67K9aXgve/oeURC+BQF/ynWAg8H5PHLNz8BxZ8e8kC2q5ZwPh1WfB//XkYJuIESrE8KXdSknY+eG9tjNCSQOyvCQye4C94OX3anH4cvW/2+8W3PwE=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <rect x="30" y="0" width="110" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 31px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                meta=wikibase
-                                <br/>
-                                API
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="85" y="60" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
-                    meta=wikibase...
-                </text>
-            </switch>
-        </g>
         <rect x="190" y="0" width="110" height="110" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>

--- a/systems/WikibaseClient/diagrams/05-api-pageterms.drawio.svg
+++ b/systems/WikibaseClient/diagrams/05-api-pageterms.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="321px" height="576px" viewBox="-0.5 -0.5 321 576" content="&lt;mxfile host=&quot;3853b922-fe25-459b-9c0f-03705851cae9&quot; modified=&quot;2021-01-13T14:54:58.620Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;Q9mB3zYzUXhabNeJiDxT&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;7VfbjtowEP0apPaBKlcDj5Cl260WqV2q7rOJJ8SNibOOw6VfX4fYkBBoUaFUavcJ+8yMxz5nPDgdN1is7wXO4gknwDqORdYd967jOLbleeqnRDYV0resCpgLSrTTHpjS72AiNVpQAnnDUXLOJM2aYMjTFELZwLAQfNV0izhrZs3wHFrANMSsjT5TImONIt/bGz4AnccmtY0GlWWBjbc+Sh5jwlc1yB133EBwLqvRYh0AK9kzxFRx709YdzsTkMpzAgI0W0Uvm28Q+UWQLLvJx8nXrt2rllliVugjdxzE1IIjQpdqOC+HT5DxR5omIIxxJozNICpxLUIfWW4MkauYSphmOCznK1UsyimWC6ZmthriPKvki+ga1IZHEWUs4IyLbbgbRZEThgrPpeAJ1CwEzZCPygieSl1Atm/megNWmyzN3xKEhHUN0uTdA1+AFBvloq0DV6+iS9nt6flqXxgDDcW1kjAY1qU43628F0sNtF7HtXNPqlSessE0eim4MXTzLR9D5WD72XpvNDJlgish7soqliAWeVve4aeHmsJVthMSC16kpBRP0e2OfiH4gb7Ehz7xjunbd2YuQrt8F0nYO5DQttsS2v4RDXeOl4jo/fyq/a6Gw4x+LkBs1B2CU5fxCmnMInmGU4O9mQCh+JkmVIXNtvmtkOE8f1vbSD3gzGZxSSWd0Smu0Qysv1lJfquSttfUeoI842kpwxUJBVtdzt4xQgeo5+LD1tv/E633gG3HuyXbqMX2I+dJoV4g/xjNh+3xtjSf9RL5ov6lRkUU/dcvkR5q6uT1vXf+zd4i/XN0GjKK81exjojlD24p1uAcscappHLzQKq29qrVLZ74arr/9Nvaal/Q7vgH&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="321px" height="576px" viewBox="-0.5 -0.5 321 576" content="&lt;mxfile host=&quot;8d3faec5-d055-4702-88a8-cd468e466b4d&quot; modified=&quot;2021-02-02T10:51:01.695Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;EhtDyuPUbOrZipVApxN0&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;7Vddk5MwFP01ndGHOuW7PLZY13W2M7p13OcULiUSCBtCAX+9oSQFlq7WsdYZ3ZfOzbn35uOcAykTw0uqG4ayaE0DIBN9FlQT4+1E111NF78NULeAqbktsGM4aCGtAzb4G0hwJtECB5APCjmlhONsCPo0TcHnAwwxRsthWUjJcNUM7WAEbHxExugDDngkUdsyu8R7wLtILa3Z8oAJUtXyKHmEAlr2IGM1MTxGKW+jpPKANOQpYtq+d89kjztjkPJzGjx7W4aP9VcIrcKL99P4w/rLVHPaafaIFPLIE90mYsJlgPci3DXhPWT0DqcxMJXcMpVTiFi41yGPzGtFZBlhDpsM+c24FF4RRRFPiBhpIkR51soX4grEhpchJsSjhLJDuxGGoe77As85ozH0MoG9tS276aAplwbSLDWWG5iNyZL87YFxqHqQJO8GaAKc1aJEedmQs0grG44cl50xXAlFPUsoDEkr7o4zd2KJQOp1Wjvzxyr1iLYfi8ZQh9NP8wMdC1GgWVnVJZVKiwx/KoDVgn54TscLLKMmyTOUKuzVGgKMHnCMRdv2sP7MJyjPX/c20m8402eMFmnQOEhobix/4rpfN9klfDQb+kjTxj7SrBNGOhb+jpOskZMWH28FcA95RtNGhgsSClpggXOKUNd2DPT0qZ3/iaf2Cdu6eU227RHbd5TGhbi8/jGaHeNv0nzWJfYZWLIswvC/vsQce6iTOTffWFe7xubn6LQgGOUvYp0Qy3KvKZZ7jlirlGNe3wbta+1Fq2v8OxTD7qvhkOt9exmr7w==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="200" y="260" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
@@ -18,27 +18,6 @@
                 </foreignObject>
                 <text x="245" y="310" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     RepoLinker&#xa;
-                </text>
-            </switch>
-        </g>
-        <rect x="0" y="0" width="150" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 55px; margin-left: 1px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                <font style="font-size: 15px">
-                                    prop=pageterms
-                                    <br/>
-                                    API
-                                </font>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="75" y="59" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    prop=pageterms...
                 </text>
             </switch>
         </g>

--- a/systems/WikibaseClient/diagrams/05-api-wbformatreference.drawio.svg
+++ b/systems/WikibaseClient/diagrams/05-api-wbformatreference.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="491px" height="331px" viewBox="-0.5 -0.5 491 331" content="&lt;mxfile host=&quot;f8999d5b-8b59-4d66-af54-705f7a9693ab&quot; modified=&quot;2021-01-13T14:59:34.752Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;zg8qLjA2IPntCth0QBOD&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5Vddb5swFP01SO1DJD6CA49p+rVJ0apFWp8dfAleHEyNCcl+/QwYAiJZoyxppu4J+9zr6+tzjmRjOJPV5kngJJpyAsywTbIxnHvDti1zOFSfAtlWiGeaFbAQlOikHTCjv6BeqdGMEkg7iZJzJmnSBQMexxDIDoaF4Hk3LeSsu2uCF9ADZgFmffSVEhlpFLnDXeAZ6CKqt7aQX0VWuM7WR0kjTHjegpwHw5kIzmU1Wm0mwAr2amKqdY8Hok1nAmJ5zIIJmufh2/YnhG42Wa4Hy6/THwNLl1ljlukjP3KhelfYdwhBFQ9A9y+3NSuCZzGBoq5pOHd5RCXMEhwU0Vz5QGGRXDE1s9QwpIxNOOOiXOuARVwYKTyVgi+hFfHRyMGoWMFjqa1gefVc7272j10fAYSETQvSNDwBX4EUW5Wio56vq2hT2o6e5y2JXY1FHXU1iLWtFk3tHfFqoLnfr4PTY9ywEZMFIwmOO0Sjt6xwR0nAIC0ZGasEy002u6AaLYpvPg9L5cROtqqsaqiqXOXV8Fycvtd5Oh6/fDnY4xkdp/zmkeE+x3n23EGo2e/vTGV1TdV45UNMNbyQqcYJvcPpe1YidH0uL1XYzRQIxa90SdWyedmAGTCcprdHmLqLqMSyvQsYKwxDOwj2GYugOXLPZCzfu6ax0EFjtVhtborq7pAgTtbjHQVwmlTXfEg3hWonSNK+XdwL3C6+3dXLcft6+Xvk8s+g1ugYte4hBUExUxzs0emmEfP2v5Fs5F5PMq8n2QsWaaHMp6PZMv3r8ez3eH7GMWE0Xig0Kwk3aZxk8rO9dkf2NV+7dY0W798y+W/S3ON0D/N/MDf6QJ7VdPfnWMZaP+DOw28=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="491px" height="331px" viewBox="-0.5 -0.5 491 331" content="&lt;mxfile host=&quot;2ab6e53b-6f4e-4f77-aa5b-c58525061dc2&quot; modified=&quot;2021-02-02T10:51:07.920Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;tHsZCbpElmR49jFY0eZo&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5Vddb5swFP01SO1DJD6CEx5b+qVJ0aZFWp8dfAEvDqbGBLJfPwPma6RqlXWNlL0k9rnX19fnHCwwHH9XPgqcxitOgBm2SUrDuTNs27Ns9VsBhwaYW14DRIKSBrJ6YE1/gQZNjeaUQDZKlJwzSdMxGPAkgUCOMCwEL8ZpIWfjXVMcwQRYB5hN0WdKZKxR5M77wBPQKG63tpA+4A632fooWYwJLwaQc284vuBcNqNd6QOryGuJadY9vBLtOhOQyPcs8NGmCF8OPyF0c3+7n22/rH7MLF1mj1muj/zAhepdYd8hBFU8AN2/PLSsCJ4nBKq6puHcFjGVsE5xUEULZQOFxXLH1MxSw5Ay5nPGRb3WAYu4sFB4JgXfwiDioYWDUbWCJ1JbwVq2c727OT12ewQQEsoBpGl4BL4DKQ4qRUeXnq6iTWk7el4MJHY1Fo/U1SDWtoq62j3xaqC5P67DfMK4YSMmK0ZSnIyIRi955Y6agFlWM3KjEiw3LfugGkXV/01Kb3EGbTHVRlOvibYwofvTtxg32mBXKyAUP9MtVcs2dQNmwHCWXb/RyUb8iajEur0W/UDXhWFoB8Ex1xG0QS7q9vsrY3nLsbE6v3yKsdCrxhqw2j3UzWMuQZysxxsK4CxtbuSQlpVqJ0gyvAjcf3ARePZYL8ed6uUdkcv7ALUW71HrDjIQFDPFwRGdrjoxr/8byRbu+SRbTiT7hkVWKXNxNFumdz6evQnPTzghjCaRQvOacJMmaS4v7cVkYZ/zxaStMeD9ay4vkGbLRJ/Is5r2L/l1bPCp5Nz/Bg==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="170" y="120" width="150" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
@@ -15,29 +15,6 @@
                 </foreignObject>
                 <text x="245" y="180" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
                     Format Reference
-                </text>
-            </switch>
-        </g>
-        <rect x="90" y="0" width="150" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 55px; margin-left: 91px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                <span style="font-size: 15px">
-                                    wbformatreference
-                                </span>
-                                <br style="font-size: 15px"/>
-                                <span style="font-size: 15px">
-                                    API
-                                </span>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="165" y="59" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    wbformatreference...
                 </text>
             </switch>
         </g>

--- a/systems/WikibaseClient/diagrams/05-entitychangenotifications-usage.drawio.svg
+++ b/systems/WikibaseClient/diagrams/05-entitychangenotifications-usage.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="641px" height="616px" viewBox="-0.5 -0.5 641 616" content="&lt;mxfile host=&quot;0cf24454-44bd-42d5-9c3e-d1c0ddc29264&quot; modified=&quot;2021-02-01T10:27:50.342Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;kWN8u9aIShJHMRQbEoqg&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5VnbcpswEP0aP2bGgMH4MbGTdDLNNDPu5VmAwIqFRIXwpV/fxRY2INyShto1fYq0u0LxOXuFgTWNN48CJYtnHmA6MIfBZmDNBqZpjI0R/MklWyUxbHcviQQJlOwomJMfWAmHSpqRAKcVQ8k5lSSpCn3OGPZlRYaE4OuqWchp9dYERVgTzH1Edek3EsiFkjr26Kj4gEm0KK42nMleE6PCWv2UdIECvi6JrPuBNRWcy/0q3kwxzeErgNmfezihPfxnAjPZ5sDU8dbh9+0rDu1sulzdLJ+ev96Y1v4xK0Qz9ZMHpkPhgXcBWcEyypfzzEt9QRJJOCvUcFHJouHQM2IAjoAtihPYMy9NSpaeqJ+tP3EHmtwWVKwXROJ5gvx8vwZ/A6OFjCnsDFiGhNIpp1zsrK0wDE3fB3kqBV/ikiZwPMd28hOcSeVxhl3s1X1DHV0F+AoLiTclkUL7EfMYS7EFE6V1C+aV81uO2q9LnjRUskXJiQo7pJw3Ojz6SC8sFMNvYNsaaWx/SfMI0Dj5yPkyS66fg5FxQQ7MNrF1zySR20KRJogVmgo1cFdZ19eYsUf25fjSc+GJ6Lj1/SzOKJKAz9VD7owvCHnrhPRZIH+JewB3vSqMRi3htu33w223yUgv1bTz6yr/m/SV/uf5qzW7XQST0zaYZjjIEkr8fiYw22wbUR1gPm5dM9IkH1CaEhtLQy7iPiS3if2H7ZbbARVuMxW7ykFY1NDkIhZlYPGAKPXAqMnCw3SGteGnf42yFkSu3Y65g/A91E3eSt2coeUDBA2Ssg9xU0f/rGWjGJFK6M+QRJ+8V0hY6TvBxUZg43ETuBNnbKHz1ORqUjokmzK4xt8C19DAfcEiJanEDBC8enBd45Lg6hP2rZrMdsn62sF1xpcEV5/N9sWuBymh/lrovMDqU1jCk9xp87YRYICLi8FKNZM1vOsFzPVxcwHzXBhIhheYasdtG78uplpDH3yyJKjCWX6FrTtw14Bad4iSiMHaB0yhQylm205Bds/56sDQJ527jDb0zE0fC47aLzti/o2WTUO+gZ/WZLSfOrsgQ591boPgxOQJfXL+SueJe/1D3RmeE/UTY0pvfdppKosdoQvb47fPna70Ddm6/wk=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="641px" height="616px" viewBox="-0.5 -0.5 641 616" content="&lt;mxfile host=&quot;0d49cacc-08ae-4c3d-85db-f0f7254c71be&quot; modified=&quot;2021-02-02T11:00:39.179Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;QNrN4HyJ_hu8xUcShm5n&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5VnZcpswFP0aP2bGbLL9mNhJOplmmhl3eRYgQLGQqBBe+vUVRtiAcEsaatf0xSPdeyWZc3Q3GFnzePvIYRI9Mx+RkTn2tyNrMTLNmWHK31ywKwS2MSsEIcd+ITKOgiX+gZRwrKQZ9lFaMxSMEYGTutBjlCJP1GSQc7apmwWM1E9NYIg0wdKDRJd+w76IlBQ49lHxAeEwKo82gHrAGJbW6lHSCPpsUxFZ9yNrzhkTxSjezhHJwSuBKdY9nNAe/hlHVHRZMAfuJvi+e0WBk81X65vV0/PXG9MqtllDkqlHHpmAyA3vfLyWwzAfLjM39ThOBGa0VMuDKhYti54hleBwOYVxIufUTZOKpcuba5s77kETu5KKTYQFWibQy+cbedukUSRiImeGHAaYkDkjjO+trSAITM+T8lRwtkIVjQ9c4IB8BaNC3TjDKefqvLGOrgJ8jbhA24pIof2IWIwE30kTpZ2WzKu7bwE131Ru0ljJosolKu2gurzhYesjvXKgGH4D25atsf0lzT1A4+QjY6ssuX4ObOOCHJhdfOueCix2pSJNIC01NWrkWVXdUH3GsZ3L8aXHwhPecet5WZwRKCQ+Vw85mFwQ8s4B6TOH3goNAO5mVrDtjnA7zvvhdrpEpJd62Pl1lv9N+Er/8/jVmd0+nAl0daYF8rOEYG+YAcwxu3pUD5hPOueMNMkblLbARtOA8XgIwW3m/GG5Ne2Bimk7FfvMgWnYUuRCGmbS4gES4kqjNgsXkQXSmp/hFcqaE02dbswdhO+hbvZW6pYUrh6k00AhhuA3TfTPmjbKFqmC/gIK+Ml9lQErfSe4yPAdNGkDdwYmFjxPTq4HpUOwqYJr/C1wDQ3cF8RTnApEJYJXD+7UuCS4eod9qzqzfbC+dnDB5JLg6r1ZkewGEBKar4XOC6zehSUsyS9tXjZKGOTBZWOliskG3v9eAmt2tZOuhV8fXa2hNz5Z4tfhrL7C1i9w34Bad5DgkMqxJzGVFUrZ2/YK8vScrw4MvdO5y0hLzdz2seCo/bInZgAlW5OM7l1nH2Tovc6t75/oPGWdnL/SeWLu8FAH43OifqJNGeydBm1psSd05fT47XOvq3xBtu5/Ag==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="410" y="80" width="100" height="60" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
@@ -278,7 +278,7 @@
                 </text>
             </switch>
         </g>
-        <rect x="410" y="480" width="100" height="55" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+        <rect x="410" y="480" width="100" height="55" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="15px">
             <text x="459.5" y="504.5">
                 populate
@@ -287,7 +287,7 @@
                 EntityUsage
             </text>
         </g>
-        <rect x="410" y="560" width="100" height="55" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+        <rect x="410" y="560" width="100" height="55" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="15px">
             <text x="459.5" y="584.5">
                 update

--- a/systems/WikibaseRepo/05-Building_Block_View.md
+++ b/systems/WikibaseRepo/05-Building_Block_View.md
@@ -1,5 +1,7 @@
 # Building Block View
 
+![Legend](../../diagrams/legend.drawio.svg)
+
 ## Whitebox Overall System
 
 TBA

--- a/systems/WikibaseRepo/diagrams/05-api-wbeditentity.drawio.svg
+++ b/systems/WikibaseRepo/diagrams/05-api-wbeditentity.drawio.svg
@@ -1,25 +1,6 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1401px" height="800px" viewBox="-0.5 -0.5 1401 800" content="&lt;mxfile host=&quot;cf0379ac-a03e-4f1a-8886-1b25c4246a89&quot; modified=&quot;2021-01-12T12:26:25.929Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;kwjjAv1W7Ms1_rhatuk5&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;7Vtbc5s4FP41ntl9SIe78WPsuEl20l1P3WmfZeuAtQZEJeHL/voVBnwTmToTy1A7T8CRQOh8n85N0LEH8eqRoXT2hWKIOpaBVx37oWNZpuE48pBL1oXEN4xCEDKCy047wZj8B9WdpTQjGPhBR0FpJEh6KJzSJIGpOJAhxujysFtAo8NRUxSCIhhPUaRKfxAsZqXUc51dwxOQcFYNbXq9oiVGVe9yKnyGMF3uiexhxx4wSkVxFq8GEOXaqxRT3Pf5ldbtmzFIxCk3DLzJMvi5/hcCNxvMF3fzv758vyunsUBRVs54OQFMhHwmEeuO5UXy2f0Jk2dhfiaPKE7lSTLh+eF+9FzOTqwrnS1n8v5xiqb59VLyQvabiTiSV6Y8RTwtkArICuS79QMSRQMaUba53cYu+NiRci4YncNei29NbM/L76CJKLliutV1+QKGqpdSVQtgAlZ7olJPj0BjEEzO1ihbvW75lJK1vfJyuUeBiqGzA/RLISppF24fvQNGnpTYvAEnV8GpwgaTxYH6vZ9ZzqiNTu74Rkn3soPppqsCv7K9QlSuWRKshwd4y1fcPHaL+VlG+mOCOORrNUKc/7nPrXc89LVXPi8ngyCwptM6TmJv4rmX4GTXbxsnPW2cvE9Jf8MVrXSMASOyJHMie31Q8x3U7Flto6avUHPjqAwGPKVJDvV5QQBTeq1uHQg9r2ujYxB8DSCYjnuIguU0DkNPgeEJJTgiSSilGYd8fZEkzcQ14uG1Dg7TVPAYylhPSqpw7wgFRrME5/qVGrH7v8CkfRDY5gkQGL3LYmBr85pjCc8LSeZ63eY3xEIQescYMbqQeR/7cMRvtDlHeYtb44nr6N7TxnY1vzwXR4qM5RlrZiJifMfDmyOQ3W2aQPoS37Fgm0BEJ33+pixGkez3YcreyUTHb5qJ+tLdr8CzSLNL7WckwrdkyRyvbQTqaiPQfUqGjNFX0T0XTVMq1X/DHGreHaqFjQFNAhJmDAlCkyYzOB0IHGdwtm9+chUIrAun0WpZ44XSeZbyc6+BFiDgO0cINF/cq6qNGgzpYIaSELheO4rSNCIS7nwrU+9IYgZ7xZ3fKABtAfG9FhJfrd+dbRcQMEE/NnshOgk5IQneS7o+uHhiIGIc5+UtIKOlkHEEjBMuIJk2vcGiBYRtWNciEPRVky/xRUDhbv9JL1tNvvq8xTvaCXStuqjZNOqoamijqloKruA/e9zcBgyMQww8sw6DiyaPlr5a6mUW8gNwYKSop74ao18dk7otZJJaC4UETSLAhdf4tk5BXdTvqUW0AIfjWkS9Va2tRTjagFBrihOEQ3gWEF8/AKcXg/QBoBbkuFRrRJL5o1R3jWu7MhA8pwUgqAW5gZy2nOSLdEsZCq/fGHWN5mGw1bpcymgq57R+QALdhFPotsAm2XVlIicAmQIhAXhUYEKADwuffe2Y+I7fPCZqteR3StS/woLwzf6SzlGKXZSbCez9o91FrzKgTYX1tpqil/E8EdH2a/zdz0AVXlePjGs1jYy+1P0S5mMELCZcvwEZzGA6v6FCn2n47gnReM+toaqri6r6vpMqPlbXSaBxFseIaV4NTxClt0zSWmt6UYrq+xKrsKZjtND+aWnFos96hykm9EIRvtiMbmVdWD3r069XhmnULI2t8A1rQ17ufjbftO39s28P/wc=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1401px" height="800px" viewBox="-0.5 -0.5 1401 800" content="&lt;mxfile host=&quot;4676fecf-7b38-40df-bc7c-a84032da121c&quot; modified=&quot;2021-02-02T11:26:46.669Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;SixelA3i7y4npsmn_lQa&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;7VvbcuI4EP0aqnYfMuU78BgIk2Qrs5sapmaeBWobLbLlkWQI+/UrYzlg7NQkFYQ9kJfEbsm6ndPd6pboueP46ZajdPGFYaA9x8JPPfem5zhD21F/c8GmEHj2sBBEnOBCZO8EU/IfaKGlpRnBICoVJWNUkrQqnLMkgbmsyBDnbF2tFjJa7TVFEdQE0zmidekPguVCSwPf2xXcAYkWZdd2oCcYo7K2nopYIMzWeyJ30nPHnDFZPMVPY6D54pULU3z3+YXS55FxSORrPhgHs3X4c/MvhH42Xq6uln99+X7lF62sEM30jHtOQFV7I0xW+aDlRi9F8DPLRzoKWSKvxBaoa1XB9lOF9WhXrp6i/L+iAgk3k0QSuSnbVIPbNlvUOFZPf8yQgJwDFAnxZ9nqjL+r0ZeG7FRaddYLImGaonn+vlYqoCotZEzVm60ekUgLVobkCXDePaF0zCjj28/dMAyd+VzJheRsCXslOJgFfqAHrPXC9st3PQCrzgFNixVwCU97Is2JW2AxSK4QsXRpf6Bb0Ro61K/rPbqX2rioMF0LkVax6LnpHQnVg+bhGzgZGOPkdUpGW64YpWMMGJE1WRJV64Oa76Dm0OkaNQc1al4/3isBB5GyJIf6uCCAjX3oN4EwDPouOgRhYAAE2/OrKDhe6zAMazDcoQRTkkRKmgnI9YskaSbPEY+gc3DYdg2PCSZq8S3Q7v8ABc6yBOfrq1bEHf0Ck+5B4NqvgMAanhYD15jXnCp4HkiyNOs2vyEegTTbxyNnKxVP8A9H/Eab068S3m/wxE10Hxpju2eM7UXEco8NMxFxsePhxRHI7bdNIHOB71Ty7UbEJH3+ZjxGVNX7MGXvZKI3aJuJ5sLdryAyatiljjJC8SVZMi/oGoH6xgh0nZIJ5+xFdI9F05Sp5b9gDrXvDuuJjTFLQhJlHEnCkjYjOBMIHEZw7sD+5NcgcE4cRtfTGg+MLbNUHFsHOoDAwDtAoP3kXpltNGBIxwuURCDM2lGUppQouPMjMrM9yQXsJXd+ow1oB4gfdJD49fzd0U4BARP0Y3sWYpKQM5LgvaDrg4uv3IhYh3F5B8jo1Mj4CFwQISGZt33AYgSE521dh0Awl00+xY2Awt3+k542m3z2cUtwcBLoO027ZttqoqpljKr1VHAJ/9H3zV3AwKpiENhNGJw0eHTM5VJPo8g3IICTIp/64h797JjU7yCT6rlQSNCMAi68xrdNCnWlfk8uogM4HOYimq1qYy7CMwZEPac4QziCewnx+QPw+mSQOQDqCTmhlpWSZHmrlrvBtZ0ZCIHXARDqCbmxmraa5INySxmKzt8Y9a32YXDrebmUs1TNaXODJLoIp9DvgE1ym9JEXggqBEIS8GOBCQExKXz2uWMy8AbtY1LPlvxOgfpXWBGxPV8y2UtxinIxG/vBweliUBrQtrb1bj1E1/t5Iunzbfw8aVvF6+yR8Z22kTEXup/CfDwCj4kwb0DGC5gvLyjRZ1sD/xW78aHfQFXfFFXN3ZMqLqubJNA0i2PEDWvDHdD0kknaaE1PSlFzN7EKazpFK+NXS0sWfTbbTTGhB4bwyWZ0KXrhDJ1Pv9YM22pQjWfhG3RDve5+xLwt2/spuDv5Hw==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <rect x="510" y="0" width="110" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 511px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                wbeditentity
-                                <br/>
-                                API
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="565" y="60" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
-                    wbeditentity...
-                </text>
-            </switch>
-        </g>
         <rect x="620" y="0" width="110" height="110" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
@@ -393,6 +374,108 @@
                 </foreignObject>
                 <text x="585" y="571" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     ChangeOp...
+                </text>
+            </switch>
+        </g>
+        <rect x="150" y="431.5" width="210" height="40" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 208px; height: 1px; padding-top: 452px; margin-left: 151px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                enabledEntityTypes
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="255" y="456" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                    enabledEntityTypes
+                </text>
+            </switch>
+        </g>
+        <rect x="150" y="491.5" width="210" height="40" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 208px; height: 1px; padding-top: 512px; margin-left: 151px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                badgeItems
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="255" y="516" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                    badgeItems
+                </text>
+            </switch>
+        </g>
+        <rect x="150" y="551.5" width="210" height="40" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 208px; height: 1px; padding-top: 572px; margin-left: 151px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                sitelinkGroups
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="255" y="576" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                    sitelinkGroups
+                </text>
+            </switch>
+        </g>
+        <rect x="150" y="611.5" width="210" height="40" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 208px; height: 1px; padding-top: 632px; margin-left: 151px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                ContentLanguages
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="255" y="636" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                    ContentLanguages
+                </text>
+            </switch>
+        </g>
+        <rect x="150" y="691.5" width="210" height="40" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 208px; height: 1px; padding-top: 712px; margin-left: 151px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                propertyDataTypes
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="255" y="716" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                    propertyDataTypes
+                </text>
+            </switch>
+        </g>
+        <rect x="150" y="758.5" width="210" height="40" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 208px; height: 1px; padding-top: 779px; margin-left: 151px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                $federatedPropertiesEnabled
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="255" y="783" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                    $federatedPropertiesEnabled
                 </text>
             </switch>
         </g>

--- a/systems/WikibaseRepo/diagrams/05-api-wbmergeitems.drawio.svg
+++ b/systems/WikibaseRepo/diagrams/05-api-wbmergeitems.drawio.svg
@@ -1,25 +1,6 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="731px" height="461px" viewBox="-0.5 -0.5 731 461" content="&lt;mxfile host=&quot;7b9f91bd-9cc5-4dfc-9be0-7633582fdb79&quot; modified=&quot;2021-01-11T16:59:08.887Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;796TBKeckk28colLUMc9&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5Zhdb5swFIZ/TaTtohLmK+SyybI2kyJVq7ReG2zAi8HUmJDs1+8ApgkhUT9G2mi9wn59/HWeN9hhZM2SzY3EWbwUhPKRaZDNyPo2Mk1k2DY8KmXbKJ5hNEIkGdFBO+Ge/aFtT60WjNC8E6iE4IplXTEQaUoD1dGwlKLshoWCd2fNcER7wn2AeV99YETFWnUde9dwS1kUt1Mjd9K0JLiN1lvJY0xEuSdZ85E1k0KoppRsZpRX2WsT0/T7fqL1aWWSpuolHWauX4aP2980dIrZan21+rH8daW3sca80Dsu/YTKiDJFk3xkuhzGnvoSSlFVgidOMiikfl49ru8Wendq2+asjKHzfYaDql6CLyAuVgmHGoIizrOGVMg2FNY2DRnnM8GFrLtbxKEesUHPlRQrutfimb7lulUPkSrtFeS0db0Ao58Xnao1lYpu9iSdpxsqEqrkFkJ069jSo2xbqrpe7nmg1eIOfi1i7bvoaewdGShoOK8A5fZAtXAIW3fy7z4WlaXqpFzldZauIQA52WbX2PK8zhgAoe1YsLR6uCfY/z7DlyUlDD+wFYMQv57LCDjO86/77nrr6KcWPqwlwzA0g+CYJYnru857WNKbXJwlvZ4l67eBIWmeibQCPSwFiuDVMD5GYeKOLXxIwTsDBYTMLgbT/nAMkx6GW5wSztII1CKn1a+LpVmh/kMejnFxOBDq8VhWBypIi+ZMPaAgRZGSKr+QEWv6DJPLQ+A6zyOwrfdF0L/VvOUoq0+Xg/Nmniqmtgsy3IF5bJY7LOvf7Sc52xzUtZA17ltocsRBk7MZaJjb1jG0P2lewEBntc+0YJx8Iv8gdHBft72PNtD4bAaCG/sc/tiepDuUTTMB6f/EHnrPl5A5iFt6EKv7Rn33WKSAEgfqtGtex/Py8I295+mhgfBBdffVpm7b+/hlzf8C&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="731px" height="461px" viewBox="-0.5 -0.5 731 461" content="&lt;mxfile host=&quot;fe2b50e3-4c10-426a-b44d-65216883a0c8&quot; modified=&quot;2021-02-02T11:26:53.080Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;GyaWPJAZuElKT97Uc-mv&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5Vhdb9owFP01SNsDEs4X5LFkrGUSUjWk9dnEN4mHE6eOQ2C/fk7iFNKAaKfQovEC9rnX9177HMdOBqYXb+8FTqMFJ8AGxohsB+a3gWG4yFC/JbCrAQu5NRAKSmoI7YEl/QMaHGk0pwSylqPknEmatkGfJwn4soVhIXjRdgs4a2dNcQgdYOlj1kWfKJGRRh3b2hsegIZRkxo5eoIxbrz1VLIIE14cQOZsYHqCc1m34q0HrFy8ZmHqcd9PWF8qE5DItwzwnFURPO9+Q2Dn3nozXP9Y/Bo6dZQNZrme8cBwmIo3JXRTFi13eimc57ysdBrwRA6ziqg75YDsdLs3qlZY/t+ldIozaGKpoqpwtbGXDF8WQCh+omuqXFZVrpHPcJZ9bcKvxL9HP1W40QppFBGVsEyxX/YLtQGUUyRjpnpINXGW1poM6BZImZsy5nHGRTXcDILA8H2FZ1LwNRxYiLNybEdXq3cFspu+LmDUVYAWxQaEhO0BpBVxDzwGKXbKRVsnro6ya/Sr+8WB2hssagldg1jvsPAl9l6DqqFl+A5JTjqSvHucK0BAlvKkJLpfFgARG8bHWHCdsYlfszC5AAsIGW0aDOvTaXA7NDzghDCahArNMyh3F03SXP6HfNijq6MDoQ4fCxBh+dibS4izDguC5wkp11etiDk9w8n1UeDY5ymwzI+lwOrlsKxOl1fnzSyRVO7mpL8D81iWRyyqfXsjZ5uN2hIyx10JuUcU5F5MQP3cto5R+xOyXAW6qHymOWXkhvSDkNkWkDX5bAGNLyYgdWOfqfelk+z2JdOUq+W/YQ195EPI6EUtHRLL+0Z195gnikrsy9OqeR+f10ffeHKePdQTfaq7/xhQ2Q4+qZizvw==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <rect x="230" y="0" width="110" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 231px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                wbmergeitems
-                                <br/>
-                                API
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="285" y="60" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
-                    wbmergeitems...
-                </text>
-            </switch>
-        </g>
         <rect x="390" y="0" width="110" height="110" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>

--- a/systems/WikibaseRepo/diagrams/05-interactor-itemmerge.drawio.svg
+++ b/systems/WikibaseRepo/diagrams/05-interactor-itemmerge.drawio.svg
@@ -1,30 +1,11 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="626px" height="541px" viewBox="-0.5 -0.5 626 541" content="&lt;mxfile host=&quot;e0f53a8e-d7da-40f8-a24f-bd75766eead3&quot; modified=&quot;2021-01-12T12:28:17.704Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;J3opWBKHmZElaztGbllm&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5VnbjpswEP2aPK7E1YHHLs1ut2qkqqm6zw4M4AYwa5wL/foOwWyg7FatFBMpeUnsGXtsnzkej83MDvLDo6BluuQRZDPLiA4z++PMskzDcfCvkdStxDOMVpAIFqlGJ8GK/YKup5JuWQTVoKHkPJOsHApDXhQQyoGMCsH3w2Yxz4ajljSBkWAV0mwsfWaRTJWUuM5J8QlYknZDm8RvNTntWqulVCmN+L4nshczOxCcy7aUHwLIGvQ6YNp+D+9oX2cmoJD/0iEg6338Uv+E2N0Gm93d5vPyx51axo5mW7XiJwn5EgTCYpEMDd+vBZaSpvRUSBA0lFyoFcm6w2mfMgmrkoZNfY9cwOapzDOsmVikVdl6J2YHwPncxyzLAp6hpaa7HbngRQ7KKyn4Bnoaz1rbhDQ9eCEVP0y3q6sJGGMsFDw7EBIOPZHC5hF4DlLU2ERp57ayUneeVPV9z++dLB24XAmp4lryavvkDSwoh/yHc0wy8k7nlIjtBg4gL9uGR0dU7qojTB+wgemWh5Oy8+PAvTizo7FWdRb7D0eO1O+NcF7qxHFsheFb1InImrhTUIeg1T51bDKmjv8Gc/wzEGe8gb9wvtlieDwzzmDiJp2/hbNP5jb9E2dPyxa1BjhbzpRb1B0hvYSI0We2YShesyJiRXKFqHvEvSDq4xD4FUTFKgkFQnp9aPv+JdGej9AOUlokmIGh3bLMGKLWZGDNT4rwG7hQJusr9AMxLukHT8/Bvzh66xuGLdHgry8DCARQyXihcYh+MnqjeYYzYZ7h62XkjlV66dJmRTdDlbkzTJWmTEm7AKiHK9+ZzGCF217nDebG2TJlYDFNPWxZbfOcvn8JPcc1l4ucSjyFboYn3vxyF13T0hlV8FKRs0rzGRSkEG5umC6ThhVbD10mIcqSFjS5YaK4UxJl/IJ2xrjy10Tl6vxoGsYFD4jxA13Ai5hd45uc4w0/Vmh9ncDq6SvVUdf72GcvfgM=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="626px" height="411px" viewBox="-0.5 -0.5 626 411" content="&lt;mxfile host=&quot;3af3e781-5615-4bc4-8b4a-5c7a3114b798&quot; modified=&quot;2021-02-02T11:27:05.651Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;JIsmg7DEBSvYLzzJDv3d&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5VnbjtsgEP2aPK5kfCHxY9d7aatGqpqq+8zaY5sGGy8mt359xzbexPVuVakhkZKXBA4wwJkDDHjiRcX2UbEqn8sExMR1ku3Eu5u4bkhc/G2AXQf4JOyATPGkg8geWPBfYEDHoCueQD2oqKUUmldDMJZlCbEeYEwpuRlWS6UY9lqxDEbAImZijD7xROcGpYG/L/gIPMv7rgk1EyxYX9tMpc5ZIjcHkHc/8SIlpe5SxTYC0ZDXE9O1e3in9HVkCkr9Lw0i+rxJX3Y/IQ1W0XJ9s/w8/3FDaGdmzcTKTHniUoEGbxO+bkatd4YL+rJqhnqbylLf1K2nPmAFElTbfSGmsuZ/DgqJNZZwTK2xrugo9h9YrKXavdeDO7DsbnKuYVGxuMlvUKhYKdeFwBzBJKurTjsp30LSDIELEUkhVdvcS9PUjWPEa63kEg5KEvpMA2oGbdRLgj5vBuCMPWWctwalYXsAGc89gixAN9NzTClFq20Ts448aqxu9qoMDZQf6LHHmFkH2avlvVIwYcTytnD8kUS+SLlc4Qo8Ms9AkgCmb/Ec0qnH/uR5ZoHnqecOeHb9Mc+EvEH0K/g/TAcjpueQcPbElxzhZ14mvMwukPUZDc7I+ngL/Aqq5rWGEim9PLbD8JxsT0dsRzkrMzzk0W5VCY6sNYd885Mj/Q5OlOvdBfqBOuf0w8zOwX/feusbbluq4d9eBBApYJrL0mIXn0oNqg00rjbO8E8YZ4R2FbnmtV25dFHR1Uhl6g9DpVOGpP0GaEcr37kWsMBlb/MGc+VqOeXGQogdtSxWRcHev4Qe45orVcE0nkJXo5PZ9HwX3f6xys6ugpeKgteWz6Aoh3h5xXI56bbi2ZHLSYQyZyXLrlgowSmFMn5BO+K+8tdA5eL8SBznjAfE+IEukmXKL/FNzp85A56tvk5gdv8hpC07+Jzk3f8G&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <rect x="250" y="0" width="110" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <rect x="135" y="120" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 251px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                ItemMerge
-                                <br/>
-                                Interactor
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="305" y="60" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
-                    ItemMerge...
-                </text>
-            </switch>
-        </g>
-        <rect x="135" y="250" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 295px; margin-left: 136px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 165px; margin-left: 136px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 <div style="font-size: 15px">
@@ -37,16 +18,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="180" y="300" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                <text x="180" y="170" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     Merge...
                 </text>
             </switch>
         </g>
-        <rect x="252" y="130" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
+        <rect x="252" y="0" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 185px; margin-left: 253px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 253px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 18px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 Lookups
@@ -54,16 +35,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="307" y="190" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
+                <text x="307" y="60" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
                     Lookups
                 </text>
             </switch>
         </g>
-        <rect x="385" y="130" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
+        <rect x="385" y="0" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 185px; margin-left: 386px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 386px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 18px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 MediaWiki binding
@@ -71,16 +52,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="440" y="190" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
+                <text x="440" y="60" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
                     MediaWiki bi...
                 </text>
             </switch>
         </g>
-        <rect x="515" y="130" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
+        <rect x="515" y="0" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 185px; margin-left: 516px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 516px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 18px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 Persistence
@@ -88,16 +69,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="570" y="190" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
+                <text x="570" y="60" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
                     Persistence
                 </text>
             </switch>
         </g>
-        <rect x="125" y="130" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
+        <rect x="125" y="0" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 185px; margin-left: 126px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 126px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 18px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 Changes applied to the entity
@@ -105,16 +86,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="180" y="190" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
+                <text x="180" y="60" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
                     Changes appl...
                 </text>
             </switch>
         </g>
-        <rect x="135" y="350" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <rect x="135" y="220" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 395px; margin-left: 136px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 265px; margin-left: 136px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 <div style="font-size: 15px">
@@ -130,16 +111,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="180" y="400" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                <text x="180" y="270" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     EntityRedire...
                 </text>
             </switch>
         </g>
-        <rect x="262" y="250" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <rect x="262" y="120" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 295px; margin-left: 263px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 165px; margin-left: 263px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 <div style="font-size: 15px">
@@ -152,16 +133,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="307" y="300" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                <text x="307" y="170" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     EntityRevisi...
                 </text>
             </switch>
         </g>
-        <rect x="262" y="350" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <rect x="262" y="220" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 395px; margin-left: 263px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 265px; margin-left: 263px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 <div style="font-size: 15px">
@@ -174,16 +155,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="307" y="400" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                <text x="307" y="270" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     EntityTitleS...
                 </text>
             </switch>
         </g>
-        <rect x="395" y="250" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <rect x="395" y="120" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 295px; margin-left: 396px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 165px; margin-left: 396px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 <div style="font-size: 15px">
@@ -196,16 +177,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="440" y="300" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                <text x="440" y="170" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     Summary...
                 </text>
             </switch>
         </g>
-        <rect x="395" y="350" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <rect x="395" y="220" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 395px; margin-left: 396px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 265px; margin-left: 396px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 <div style="font-size: 15px">
@@ -218,16 +199,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="440" y="400" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                <text x="440" y="270" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     EntityPermis...
                 </text>
             </switch>
         </g>
-        <rect x="395" y="450" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <rect x="395" y="320" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 495px; margin-left: 396px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 365px; margin-left: 396px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 <div style="font-size: 15px">
@@ -240,16 +221,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="440" y="500" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                <text x="440" y="370" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     Permission...
                 </text>
             </switch>
         </g>
-        <rect x="525" y="250" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <rect x="525" y="120" width="90" height="90" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 295px; margin-left: 526px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 165px; margin-left: 526px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 <div style="font-size: 15px">
@@ -259,16 +240,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="570" y="300" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
+                <text x="570" y="170" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
                     EntityStore
                 </text>
             </switch>
         </g>
-        <rect x="0" y="130" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
+        <rect x="0" y="0" width="110" height="110" fill="#e1d5e7" stroke="#9673a6" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 185px; margin-left: 1px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 1px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 18px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                 Config
@@ -276,7 +257,7 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="55" y="190" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
+                <text x="55" y="60" fill="#000000" font-family="Helvetica" font-size="18px" text-anchor="middle">
                     Config
                 </text>
             </switch>

--- a/systems/WikibaseRepo/diagrams/05-special-mergeitems.drawio.svg
+++ b/systems/WikibaseRepo/diagrams/05-special-mergeitems.drawio.svg
@@ -1,23 +1,6 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="731px" height="461px" viewBox="-0.5 -0.5 731 461" content="&lt;mxfile host=&quot;12c98b55-c4cd-4882-b2ca-2f1ed863b97d&quot; modified=&quot;2021-01-08T12:14:00.950Z&quot; agent=&quot;5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;A1L8zPX1iFvWUDEBJH0N&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5VjdbpswGH0aLiNhDIRcLixrM61StVTrtYNN8OLY1JiE7OlnwDQhpGs3QRqtV9jHn//OObY/YcFwU9xIlCZ3AhNmOTYuLPjZchxgu67+lMi+RgLbroGVpNgEHYAF/UWangbNKSZZK1AJwRRN22AkOCeRamFISrFrh8WCtWdN0Yp0gEWEWBd9pFglBvU999BwS+gqaaYG/qRu2aAm2mwlSxAWuyMIziwYSiFUXdoUIWElew0xdb8vL7Q+r0wSrt7SIfSXu/hp/5PEXh6ut6P117sfI7ONLWK52fEiJRFFZcc7IjU5jj1XZJOZPah9w8wuoYosUhSV9Z1W34LTRG2YrgFdRFla6xHTgugVTGPKWCiYkFV3iD0SYFfjmZJiTY5aAmcJfb/sIbgyjgBeUzcLsLu7N4RsiVSkOIIMGzdEbIiSex1iWsfQjLJvtDP13ZHSDZa0RDYgMu5aPY994F8XjAR/IYffkcNyfKannWK6bfHvP+WlcSpSRlnF0icdALy0ODTq0qr8HjR9pGu6RFkp631pfTO6Xmw1QR3et9ZxHDtRdE5r7C997xJaB5Or0zroaP2dZKngpTj98k+APm3jc/xP/DFEp/wHA/APgNMWwHHfXYBJR4BbxDGjfKXRPCOyHICnufoP9fDsq5MDgI4ef36BpMg5LvnVjMDpK5pcnwS+97oELrysBN104F/en+rhOXmCZlxRtZ/jl16cfma5R7I6tx/kVfNA20Jw3LXQ5IyDJoMZaKAEZlZEJFVU8P7s05njm9Bpv475OPYB4CQDdoP39s94IP9Ut88DVezFlLcXB4l1nn5c+1zy+nGGMUqZaVRZx5wrIlGkRE/XwfXJNw5eVw8MJR8cRr4HzSUPExKtBzzmfVvjMke9Y4wz9nlzojHgQ6Grh39iVdvRr0U4+w0=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="731px" height="461px" viewBox="-0.5 -0.5 731 461" content="&lt;mxfile host=&quot;85e7e311-b4e2-4b41-bda2-8b50a027fcd5&quot; modified=&quot;2021-02-02T11:27:11.136Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;o-gZqgN0ueQhZXNKjrFF&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;z8QKpxzU2QkLtF4y4z4w&quot; name=&quot;Page-1&quot;&gt;5Vhdb5swFP01eawUQyDhcWVZ22mVqqVan118CV6MTY0JZL9+NjgflEbZJGiz5SWxj6997XOOP8TIDdPqRuIsuRcE2MgZk2rkfh45ToAc/WuATQNMUNAAS0lJA6E9sKC/wIJjixaUQN4KVEIwRbM2GAnOIVItDEspynZYLFg7a4aX0AEWEWZd9IkSlVjU9yb7hlugy2SbGvl2gSneRtul5AkmojyA3PnIDaUQqimlVQjMkLclpun35UjrbmYSuPqTDqH/XMYvm58Qe0W4Wl+tvt7/uPKbUdaYFXbFI8dnerxrQtdm0mpjqfBfCjPT61hwdZXXQn3SAcjLqn2jLi3N/yKDiGKT/Ymu6DPOQRcfDNd2dD3NOkETbgna5XLKhCpYZDgy9VI7SwclKmW6hnQR51kjdkwrIGZSlLFQMCHr7m4cx04UaTxXUqzgoIX4z77n22VYuyFvW7cTGHeptWyvQSqoDiBL9Q2IFJTc6BDbOgvsKJutMWy9PLDRFktaDrIgttZd7sbei6sLVt+/0HrW0fo75JngRpx++QdEPJi+xX/gT138mv/ZAPwj5LQFcCYfLkDQEeAWc8IoX2q0yEGaAXhWqP9QD298dnIg1NHjHqQ5o8Z3CtK8o4IUBSeGX82Ie31Ck/OTwPdOSzBx31eCSS/3T33xvLqC5lxRtbkjx26cfrI8YFnv2wu51TzUtpA77VooeMNBwWAGGugBM68iyBQVvD/7dHJ8E/qdqWMuxz4IuW3/TGYf7Z/pQP6pT59HqtjRJ28vDhKrIrtc+7zn8eMMYxTz0qhfHXdcgcSREj0dB+cn33R2Wj00lHzuMPI9ai55mEC0GnCb922Nf2Crv35oDHhR6Or+I0zddvApy53/Bg==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <rect x="230" y="0" width="110" height="110" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 55px; margin-left: 231px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 15px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                Special Merge Items
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="285" y="60" fill="#000000" font-family="Helvetica" font-size="15px" text-anchor="middle">
-                    Special Merge I...
-                </text>
-            </switch>
-        </g>
         <rect x="390" y="0" width="110" height="110" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>

--- a/systems/overview/05-Building_Block_View.md
+++ b/systems/overview/05-Building_Block_View.md
@@ -1,5 +1,7 @@
 # Building Block View
 
+![Legend](../../diagrams/legend.drawio.svg)
+
 ## Whitebox Overall System
 
 ![Context](./diagrams/05-blocks-1.drawio.svg)

--- a/systems/overview/diagrams/05-blocks-1.drawio.svg
+++ b/systems/overview/diagrams/05-blocks-1.drawio.svg
@@ -1,160 +1,160 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="915px" height="357px" viewBox="-0.5 -0.5 915 357" content="&lt;mxfile host=&quot;09a1d0c5-4f6d-4747-9076-1a5bd4f29423&quot; modified=&quot;2021-01-07T17:05:18.705Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) VSCodium/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;2gOXge3UcDMe1jESMjzS&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;XFkhv5XfGi1PEyDfdlKW&quot; name=&quot;Page-1&quot;&gt;7Vtdd5s4EP01fowPkvjyY+K4afe0u9m6bdp92SODbGsDyAfkxM6vX8lI5kMkcWJM6G7zkKBBSDAz93I1KAM0jjdXKV4tP7GQRANohZsBuhxACCzPFX+kZZtbPN/KDYuUhqpTYZjSB6KvVNY1DUlW6cgZizhdVY0BSxIS8IoNpym7r3abs6g66woviGGYBjgyrTc05Mvc6kOvsL8ndLHUMwN3lJ+Jse6sniRb4pDdl0xoMkDjlDGeH8WbMYmk87Rf8uvePXJ2f2MpSfghF0z/oj8cK/z9by982ED8B/jt/ewM6ZvjW/3EJBQOUE2W8iVbsARHk8J6kbJ1EhI5rCVaRZ+PjK2EEQjjP4TzrYomXnMmTEseR+qsuON0+11eP3R084cabte43FRaW9UyH1l5IWPrNCBPPKdOHZwuCH+qn/KHdEJpBuXRK8JiIm5IdEhJhDm9q2YJVsm22Pcr4iEOVEheEh6VTHc4WqupJiHl2UDG2sXxaucU6xslIs+bAvkRzwQg0QWO6CIR5kB4jqTCcEdSTkWan6sTMQ3DPLgkow94thtE+nzFaMJ3z+VcDJzLxig8mVpyJrIZNIBVzVLBQ8XJ6qoza4ggQvm1BzteDXct77/Uhc3nmUiBemT2s74+WMCI1Q29pSHmWFhl2Fi6i9s7FTERh3rIBEes5OE6js4D2b8I1C6S1yyjnDIZMC6xZoRxxjhnsUTlmkc0IeM9LcpYzmkUjVkkxxWzoRATfx4Ie8ZTdktKZ9zAJ7O5OBPVZt3nj5FQj2LTiP+jcfZGTn6JelfoDLoviFebliXOda0ToQ+M3oIcX09y8FCSg70iOf2CLAHny8W5MHyQqYWDXer1jNx0ahxPbtYQgJFfyXvNJK+lOk2bwB4CuzZybZTTsSE0gvrnmga3GcecxCTZvcO+Zr84sJYO0LMqEYOjtyZB34hQi/qvov4KMdi6/rMPpEavV8yIPANEmhMlfG6oyIi+EaPfHjFCW4s+DYZ2eNEfVocVrDi03M6IEf6fADVqG1DNMbWtKm364tk9YEM//+161QHz21ZjtB9ipEFQfvmRlJLeLdJ0MraiY1BNvx8J19ND0W4M0/aXMjlEmQDwxsoEolMSaVeVKa9nROpWozyyhlbpR/u8IyK1zaVhX4kUtUWkZ0L4iNdWJQpH1r60znG60jimbtXEOiXpHRWAEBT74Rn41vhwPp/DoJEPQ3fmOm47LFcXEo5JcgB2ynIdrr/gc3qRbCj/rgcRxyWVKVrFRbJxPDWODqTGnhXtoVm0v5Iwsz4TSUjjJU4WpFbCF6sPBKS3Pl/K8vClLBqP4eC8+fPMW/Jcm+s7B7kVsNnH0ZwmUHs09Op1r5GYbVT68buiQjMZDCrsPwsCz3ljGrRNsVeuxScsaaX4XtJ/sCIAwauYEZ6KGjXlPc+NoFfcaJtLrpwbv5A0nrFN3+jOblPWAaCXxJqWev9N03Y6gV0XQLD7BQTXAMLXVYi5VMZUOHNT0gTXJJ2zNJbuIDgNelfz1UnSzpd+262BpJ2vYRp6HWDG+89gBvULM2ZZtYDGJxJSvFNVvYSIXhG3IZtdu4aQdnRzTTL7Q4QqpZ+u8APMos8uuHI3zUBvoJGNGc56qZ49p6aeG77hdquekf2Mn46Tyt6LaqVaKuvj0xYRtAD+2aoIGuOGUp4knPKtLhL0jOd0orUjBcCRr/4OuMrc9LdfyVjf5Jnp9HMfOQpYsGeFTgRPyVEvWcsfQTbw5yQbvc/imX3G52u+FD4RFMI7/AKTMo7VB87m6DyZTi3t0KtipRW9dYa8oVPf+QeHta0KJ+Qu8w1jbNF7EXH5AWkmrpnv2M6TyHp9abJpg1y3xAVM8Eh1GqsFyZjFMUt66cu6UEUNn/Q79qVZH5xEOBPU8fjSrgeONN6mp/SkaBb/NZSTQfG/V2jyLw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="916px" height="356px" viewBox="-0.5 -0.5 916 356" content="&lt;mxfile host=&quot;6025a32a-8854-47d2-b902-ed7243c2b65e&quot; modified=&quot;2021-01-28T15:24:03.833Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36&quot; etag=&quot;fBhFUkP89XpVR5HcNv44&quot; version=&quot;13.10.0&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;XFkhv5XfGi1PEyDfdlKW&quot; name=&quot;Page-1&quot;&gt;7Vtdd9o4EP01PIZjSf7ikRCSdk+7my1t0+7LHmEL0Ma2OLZIIL9+JSzhD5GEBOM4u+WhtcayZM/Mvb4aKz00itdXKV4uPrOQRD1oheseuuhBCDzXFv9Jyya3+JabG+YpDVWnwjChD0QZLWVd0ZBklY6csYjTZdUYsCQhAa/YcJqy+2q3GYuqsy7xnBiGSYAj03pDQ75QTwG9wv6B0PlCzwzcQX4mxrqzepJsgUN2XzKhcQ+NUsZ4fhSvRySSztN+ya+7fOTs7sZSkvBDLpj8RX86Vvj73174sIb4D/Dbh+kZ0jfHN/qJSSgcoJos5Qs2ZwmOxoX1PGWrJCRyWEu0ij6fGFsKIxDGfwjnGxVNvOJMmBY8jtRZccfp5oe8vu/o5k813LZxsa60NqplPrLyQsZWaUCeeE6dOjidE/5UP+UP6YTSDMqjV4TFRNyQ6JCSCHN6V80SrJJtvutXxEMcqJC8JDwqme5wtFJTjUPKs56MtYvj5dYp1ndKRJ7vC+QnPBWAROc4ovNEmAPhOZIKwx1JORVpPlQnYhqGeXBJRh/wdDuI9PmS0YRvn8s57zkXe6PwZGrJmci6twesapYKHipOVledWX0EEcqvPdjxarhref+lLmw2y0QK1COzm/X1wQJGrG7oLQ0xx8Iqw8bSbdwuVcREHOohExyxlIerOBoGsn8RqG0kr1lGOWUyYFxizQjjlHHOYonKFY9oQkY7WpSxnNEoGrFIjitmQyEm/iwQ9oyn7JaUzriBT6YzcSaqzbrLHyOhHsWmEf9H4+wNnPwS9a7QGXRfEK82LUqc61onQh8YvAU5vp7k4KEkBztFcvoFWQLO1/OhMHyUqYWDbep1jNx0ahxPblYfgIFfyXvNJK+lOk2bwO4DuzZybZTTsSE0gvrniga3GcecxCTZvsO+Zb84sJYO0LMqEYODtyZB34hQg/qvov4KMdi4/rMPpEavU8yIPANEmhMlfG6oyIiuEaPfHDFCW4s+DYZmeNHvV4cVrNjXy9IWiBH+nwA1aBpQ+2NqW1Xa9MWze8CGfv6v61UHzG9bjdF8iJEGQfnlR1JKOrdI08nYiI5BNf1+JFxPD0V7b5g2v5TJIcoEgDdWJhCdkkjbqkx5HSNStxrlgdW3Sj/t85aI1DaXhl0lUtQUkZ4J4SNeW5UoHFn70jrHaUvjmLpVE+uEpHdUAEJQ7Mdn4FvjQzDFgMB9fGhZ7nh4Ka9gCS/ZZ9tfM+xXFxiOSX4Atsp+La7L4HM6kqwp/6EHEccl9SlaxUWycTxlDg6kzI4V86FZzL+S8LO+EElUowVO5qRW2ndl4ktvfbmQZeMLWUwewd5w/2ebt+S/Jtd9DnIrYLOPoz9NrPag79XrYQMx26D089uiSDMZDIp8v+wIPOeN6dE2xWG5dp+wpJFifUkvwopgBK9iTHgqytRU+Dxngk5xpm0u0XLO/ErSeMrWXaNBu0kZCIBeQmu66vw3UNtpBXZtAMHuFhBcAwjfliHmUklT4cx1SStck3TG0li6g+A06FyNWCdJMzsDbLcGkma+nmnotYAZ7z+DGdQtzJhl2AIan0lI8VZtdRIiegXdhJx27RpCmtHTNSnt9xGqlIrawg8wi0Tb4MrdNz294UY2pjh7V6rac2qqes+34HZVNbKf8d9xEtp7Uc1VS2h9fNqigxbG763qoLFvKOhxwinf6KJCx/hPJ1ozEgEcKQla4DBz8+BuhWN9l2cmky/vibuABTtWMEXwlNz1krX/ESQE3ycJ6X0cz+xjHq74QvhEUAtv8QtPyjhWH1D3R+fJdGpoB2AVK43oszPk9Z36zkLYr22FOCGnmW8eYwvgSwht5gck2PtBfOo7tvMksl5fyty3Aa9d4gImeKSajdUCZsTimCWd9GVdwKI9WwZa9qVZTxxHOBPU8fhSsAOONN6mp/SkaBZ/lZSTQfG3XWj8Lw==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <path d="M 584 76 L 584 169.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 584 174.88 L 580.5 167.88 L 584 169.63 L 587.5 167.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 584 75 L 584 168.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 584 173.88 L 580.5 166.88 L 584 168.63 L 587.5 166.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="551" y="105" width="69" height="14" stroke-width="0"/>
-            <text x="584" y="114.5">
+            <rect fill="#ffffff" stroke="none" x="551" y="104" width="69" height="14" stroke-width="0"/>
+            <text x="584.5" y="114">
                 Edits &amp; Views
             </text>
         </g>
-        <ellipse cx="584" cy="23.5" rx="7.5" ry="7.5" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
-        <path d="M 584 31 L 584 56 M 584 36 L 569 36 M 584 36 L 599 36 M 584 56 L 569 76 M 584 56 L 599 76" fill="none" stroke="#6c8ebf" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="584" cy="22.5" rx="7.5" ry="7.5" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
+        <path d="M 584 30 L 584 55 M 584 35 L 569 35 M 584 35 L 599 35 M 584 55 L 569 75 M 584 55 L 599 75" fill="none" stroke="#6c8ebf" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="583.5" y="10.5">
+            <text x="583.5" y="9.5">
                 Wikidata Editor / Viewer
             </text>
         </g>
-        <path d="M 74 306 L 167.63 306" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 172.88 306 L 165.88 309.5 L 167.63 306 L 165.88 302.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 74 305 L 167.63 305" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 172.88 305 L 165.88 308.5 L 167.63 305 L 165.88 301.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="78" y="291" width="77" height="14" stroke-width="0"/>
-            <text x="115.86" y="300.5">
+            <rect fill="#ffffff" stroke="none" x="79" y="290" width="77" height="14" stroke-width="0"/>
+            <text x="116.36" y="300">
                 TBA Interaction
             </text>
         </g>
-        <ellipse cx="59" cy="283.5" rx="7.5" ry="7.5" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
-        <path d="M 59 291 L 59 316 M 59 296 L 44 296 M 59 296 L 74 296 M 59 316 L 44 336 M 59 316 L 74 336" fill="none" stroke="#6c8ebf" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="59" cy="282.5" rx="7.5" ry="7.5" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
+        <path d="M 59 290 L 59 315 M 59 295 L 44 295 M 59 295 L 74 295 M 59 315 L 44 335 M 59 315 L 74 335" fill="none" stroke="#6c8ebf" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="58.5" y="270.5">
+            <text x="58.5" y="269.5">
                 Quickstatements User
             </text>
         </g>
-        <path d="M 74 118.17 L 168.35 68.95" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 173.01 66.52 L 168.42 72.86 L 168.35 68.95 L 165.18 66.65 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 74 117.17 L 168.35 67.95" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 173.01 65.52 L 168.42 71.86 L 168.35 67.95 L 165.18 65.65 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="93" y="67" width="69" height="14" stroke-width="0"/>
-            <text x="126.84" y="77.46">
+            <rect fill="#ffffff" stroke="none" x="94" y="67" width="69" height="14" stroke-width="0"/>
+            <text x="127.34" y="76.96">
                 Interacts With
             </text>
         </g>
-        <path d="M 74 134.48 L 168.46 187.87" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 173.03 190.45 L 165.21 190.05 L 168.46 187.87 L 168.65 183.96 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 74 133.48 L 168.46 186.87" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 173.03 189.45 L 165.21 189.05 L 168.46 186.87 L 168.65 182.96 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="112" y="159" width="41" height="14" stroke-width="0"/>
-            <text x="131.57" y="169.22">
+            <rect fill="#ffffff" stroke="none" x="114" y="159" width="40" height="14" stroke-width="0"/>
+            <text x="132.94" y="169.21">
                 Queries
             </text>
         </g>
-        <ellipse cx="59" cy="103.5" rx="7.5" ry="7.5" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
-        <path d="M 59 111 L 59 136 M 59 116 L 44 116 M 59 116 L 74 116 M 59 136 L 44 156 M 59 136 L 74 156" fill="none" stroke="#6c8ebf" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="59" cy="102.5" rx="7.5" ry="7.5" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
+        <path d="M 59 110 L 59 135 M 59 115 L 44 115 M 59 115 L 74 115 M 59 135 L 44 155 M 59 135 L 74 155" fill="none" stroke="#6c8ebf" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="58.5" y="90.5">
+            <text x="58.5" y="89.5">
                 Query User
             </text>
         </g>
-        <path d="M 234 96 L 234 154.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 234 159.88 L 230.5 152.88 L 234 154.63 L 237.5 152.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 234 95 L 234 153.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 234 158.88 L 230.5 151.88 L 234 153.63 L 237.5 151.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="218" y="109" width="41" height="14" stroke-width="0"/>
-            <text x="237" y="118.5">
+            <rect fill="#ffffff" stroke="none" x="219" y="109" width="40" height="14" stroke-width="0"/>
+            <text x="237.5" y="119">
                 Queries
             </text>
         </g>
-        <rect x="174" y="36" width="120" height="60" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
-        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="233.5" y="70.5">
+        <rect x="174" y="35" width="120" height="60" fill="#1ba1e2" stroke="#006eaf" pointer-events="all"/>
+        <g fill="#ffffff" font-family="Helvetica" text-anchor="middle" font-size="12px">
+            <text x="233.5" y="69.5">
                 Query Service UI
             </text>
         </g>
-        <path d="M 294 191 L 517.63 191" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 522.88 191 L 515.88 194.5 L 517.63 191 L 515.88 187.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 294 190 L 517.63 190" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 522.88 190 L 515.88 193.5 L 517.63 190 L 515.88 186.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="333" y="156" width="112" height="27" stroke-width="0"/>
-            <text x="388.26" y="165.74">
+            <rect fill="#ffffff" stroke="none" x="334" y="155" width="112" height="27" stroke-width="0"/>
+            <text x="388.76" y="165.24">
                 Get RecentChanges &amp;
             </text>
-            <text x="388.26" y="178.74">
+            <text x="388.76" y="178.24">
                 RDF Data
             </text>
         </g>
-        <rect x="174" y="161" width="120" height="60" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
-        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="233.5" y="195.5">
+        <rect x="174" y="160" width="120" height="60" fill="#1ba1e2" stroke="#006eaf" pointer-events="all"/>
+        <g fill="#ffffff" font-family="Helvetica" text-anchor="middle" font-size="12px">
+            <text x="233.5" y="194.5">
                 Query Service
             </text>
         </g>
-        <path d="M 644 191 L 818.37 98.97" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 823.01 96.52 L 818.45 102.88 L 818.37 98.97 L 815.19 96.69 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 644 190 L 818.37 97.97" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 823.01 95.52 L 818.45 101.88 L 818.37 97.97 L 815.19 95.69 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="693" y="146" width="65" height="14" stroke-width="0"/>
-            <text x="724.99" y="156.14">
+            <rect fill="#ffffff" stroke="none" x="694" y="146" width="65" height="14" stroke-width="0"/>
+            <text x="725.49" y="155.64">
                 Get Termbox
             </text>
         </g>
-        <path d="M 644 232.67 L 788.18 296.75" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 792.98 298.88 L 785.16 299.23 L 788.18 296.75 L 788 292.84 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 644 231.67 L 788.18 295.75" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 792.98 297.88 L 785.16 298.23 L 788.18 295.75 L 788 291.84 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="677" y="244" width="77" height="27" stroke-width="0"/>
-            <text x="714.94" y="253.51">
+            <rect fill="#ffffff" stroke="none" x="678" y="243" width="77" height="27" stroke-width="0"/>
+            <text x="715.44" y="253.01">
                 Update index
             </text>
-            <text x="714.94" y="266.51">
+            <text x="715.44" y="266.01">
                 Perform search
             </text>
         </g>
-        <path d="M 584 236 L 584 289.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 584 294.88 L 580.5 287.88 L 584 289.63 L 587.5 287.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 584 235 L 584 288.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 584 293.88 L 580.5 286.88 L 584 288.63 L 587.5 286.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="529" y="260" width="112" height="14" stroke-width="0"/>
-            <text x="584" y="270.17">
+            <rect fill="#ffffff" stroke="none" x="530" y="260" width="112" height="14" stroke-width="0"/>
+            <text x="584.5" y="269.67">
                 Perform Media Search
             </text>
         </g>
-        <rect x="524" y="176" width="120" height="60" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
-        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="583.5" y="210.5">
+        <rect x="524" y="175" width="120" height="60" fill="#1ba1e2" stroke="#006eaf" pointer-events="all"/>
+        <g fill="#ffffff" font-family="Helvetica" text-anchor="middle" font-size="12px">
+            <text x="583.5" y="209.5">
                 MediaWiki / Wikibase
             </text>
         </g>
-        <path d="M 794 66 L 619.43 172.68" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 614.95 175.42 L 619.1 168.78 L 619.43 172.68 L 622.75 174.75 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 794 65 L 619.43 171.68" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 614.95 174.42 L 619.1 167.78 L 619.43 171.68 L 622.75 173.75 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
-            <rect fill="#ffffff" stroke="none" x="694" y="99" width="77" height="14" stroke-width="0"/>
-            <text x="731.71" y="108.57">
+            <rect fill="#ffffff" stroke="none" x="696" y="98" width="77" height="14" stroke-width="0"/>
+            <text x="733.06" y="107.54">
                 Get Entity Data
             </text>
         </g>
-        <rect x="794" y="36" width="120" height="60" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
-        <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="853.5" y="70.5">
+        <rect x="794" y="35" width="120" height="60" fill="#1ba1e2" stroke="#006eaf" pointer-events="all"/>
+        <g fill="#ffffff" font-family="Helvetica" text-anchor="middle" font-size="12px">
+            <text x="853.5" y="69.5">
                 Termbox V2 SSR
             </text>
         </g>
-        <path d="M 294 291.52 L 517.81 237.49" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 522.91 236.26 L 516.93 241.31 L 517.81 237.49 L 515.29 234.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 294 290.52 L 517.81 236.49" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 522.91 235.26 L 516.93 240.31 L 517.81 236.49 L 515.29 233.5 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="11px">
             <rect fill="#ffffff" stroke="none" x="332" y="237" width="106" height="14" stroke-width="0"/>
-            <text x="383.56" y="247.48">
+            <text x="384.06" y="246.98">
                 Edits &amp; Authenticates
             </text>
         </g>
-        <rect x="174" y="276" width="120" height="60" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+        <rect x="174" y="275" width="120" height="60" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="233.5" y="310.5">
+            <text x="233.5" y="309.5">
                 Quickstatements
             </text>
         </g>
-        <rect x="524" y="296" width="120" height="60" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+        <rect x="524" y="295" width="120" height="60" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="583.5" y="330.5">
+            <text x="583.5" y="329.5">
                 Wikimedia Commons
             </text>
         </g>
-        <rect x="794" y="296" width="120" height="60" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+        <rect x="794" y="295" width="120" height="60" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
         <g fill="#000000" font-family="Helvetica" text-anchor="middle" font-size="12px">
-            <text x="853.5" y="330.5">
+            <text x="853.5" y="329.5">
                 Elastic Search
             </text>
         </g>


### PR DESCRIPTION
The legend is linked only in the building block sections.
It is also valid for Business Context sections as far as I can see.
It is not entirely correct for Technical Context sections because I can't quite figure out what was meant by some colors in those diagrams. Maybe we can address this in the next daily.