### PR TITLE
Glossary

### DIFF
--- a/systems/WikibaseClient/01-Introduction_and_Goals.md
+++ b/systems/WikibaseClient/01-Introduction_and_Goals.md
@@ -12,7 +12,7 @@
 
 - Connect a page to a Wikibase Item.
 - Show that a page is connected to a Wikibase Item in the page info.
-- Link to the connected Wikibase Item for a page in the sidebar.
+- Link to the connected Wikibase Item for an article page in its sidebar.
 - Use data from a Repo in Client pages.
 - Have data from a Repo used in Client pages update automatically when changes happen on the Repo.
 - See the "unconnected pages" on a Client.

--- a/systems/WikibaseClient/01-Introduction_and_Goals.md
+++ b/systems/WikibaseClient/01-Introduction_and_Goals.md
@@ -26,6 +26,6 @@
 - Connect pages on different Wikipedias, showing interwiki links on the connected pages.
 - Store information relating to article quality in a central place, for use in interwiki links on the Articles.
 - Have data updates which cause pages changes to be shown in RecentChanges.
-- Have data updates which cause pages changes to be shown in Watchlists, when the page being changed is watched.
+- Have data updates which cause pages changes to be shown in [Watchlists](../overview/12-Glossary.md#watchlist), when the page being changed is watched.
 - Update Wikidata’s data used on Wikipedia when it is incorrect or outdated via web interface.
 - Find wrong or missing data on a Wikipedia article and correct or add it to Wikidata.

--- a/systems/WikibaseClient/03-Context_and_Scope.md
+++ b/systems/WikibaseClient/03-Context_and_Scope.md
@@ -11,7 +11,7 @@
 
 ### Technical Context
 
-WikibaseClient is a "plugin" (= extension) that lives inside MediaWiki and adds functionality to it, which is reflected in this context diagram by embedding the WikibaseClient subsystem into a higher-level MediaWiki application. See further details on this decision in the [Solution Strategy](04-Solution_Strategy.md#developing-wikibase-client-as-a-mediawiki-extension) section.
+WikibaseClient is a "plugin" (= extension) that lives inside [MediaWiki](../overview/12-Glossary.md#mediawiki) and adds functionality to it, which is reflected in this context diagram by embedding the WikibaseClient subsystem into a higher-level MediaWiki application. See further details on this decision in the [Solution Strategy](04-Solution_Strategy.md#developing-wikibase-client-as-a-mediawiki-extension) section.
 
 ![WikibaseClient technical context diagram](./diagrams/03-technical-context.drawio.svg)
 

--- a/systems/WikibaseClient/04-Solution_Strategy.md
+++ b/systems/WikibaseClient/04-Solution_Strategy.md
@@ -2,4 +2,4 @@
 
 ## Developing Wikibase Client as a MediaWiki extension
 
-One of the main requirements of Wikibase is to make data available to MediaWiki applications. This makes it a natural choice to deliver the client (= data consumer) functionality as a MediaWiki extension. (see also [this section in WikibaseRepo](../WikibaseRepo/04-Solution_Strategy.md#developing-wikibase-repo-as-a-mediawiki-extension))
+One of the main requirements of Wikibase is to make data available to [MediaWiki](../overview/12-Glossary.md#mediawiki) applications. This makes it a natural choice to deliver the client (= data consumer) functionality as a MediaWiki extension. (see also [this section in WikibaseRepo](../WikibaseRepo/04-Solution_Strategy.md#developing-wikibase-repo-as-a-mediawiki-extension))

--- a/systems/WikibaseClient/05-Building_Block_View.md
+++ b/systems/WikibaseClient/05-Building_Block_View.md
@@ -92,9 +92,9 @@
 
 ![Entity Data Access Parser Functions](./diagrams/05-entitydataaccess-parserfunctions.drawio.svg)
 
-| Building Block         | Responsibility                                                             |
-| ---------------------- | -------------------------------------------------------------------------- |
-| Runner                 | Contains the methods called by MediaWiki when parser functions are used    |
+| Building Block         | Responsibility                                                                   |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| Runner                 | Contains the methods called by MediaWiki when parser functions are used          |
 | StatementGroupRenderer | Renderer for rendering a [statement](../overview/12-Glossary.md#statement) group |
 
 ### Scribunto

--- a/systems/WikibaseClient/05-Building_Block_View.md
+++ b/systems/WikibaseClient/05-Building_Block_View.md
@@ -23,10 +23,10 @@
 
 ![Action API Description Building Block Diagram](./diagrams/05-api-description.drawio.svg)
 
-| Building Block    | Type/Context | Responsibility                                       |
-| ----------------- | ------------ | ---------------------------------------------------- |
-| DescriptionLookup | Lookups      | Lookup client descriptions from a variety of sources |
-| RepoLinker        | Response     | Creates links to Repo Entity concepts                |
+| Building Block    | Type/Context | Responsibility                                                                                 |
+| ----------------- | ------------ | ---------------------------------------------------------------------------------------------- |
+| DescriptionLookup | Lookups      | Lookup client [descriptions](../overview/12-Glossary.md#description) from a variety of sources |
+| RepoLinker        | Response     | Creates links to Repo Entity concepts                                                          |
 
 ### [Action API EntityUsage](https://www.wikidata.org/w/api.php?action=help&modules=query%2Bwbentityusage)
 
@@ -48,12 +48,12 @@
 
 ![Action API Page Terms Building Block Diagram](./diagrams/05-api-pageterms.drawio.svg)
 
-| Building Block  | Type/Context | Responsibility                        |
-| --------------- | ------------ | ------------------------------------- |
-| EntityIdLookup  | Lookups      | Lookup EntityIds from Titles          |
-| TermBuffer      | Lookups      | Lookup buffered Terms                 |
-| AliasTermBuffer | Lookups      | Lookup buffered Aliases               |
-| RepoLinker      | Response     | Creates links to Repo Entity concepts |
+| Building Block  | Type/Context | Responsibility                                              |
+| --------------- | ------------ | ----------------------------------------------------------- |
+| EntityIdLookup  | Lookups      | Lookup EntityIds from Titles                                |
+| TermBuffer      | Lookups      | Lookup buffered [Terms](../overview/12-Glossary.md#term)    |
+| AliasTermBuffer | Lookups      | Lookup buffered [Aliases](../overview/12-Glossary.md#alias) |
+| RepoLinker      | Response     | Creates links to Repo Entity concepts                       |
 
 ### Action API Format Reference
 
@@ -79,23 +79,23 @@
 
 ![Entity Data Access Shared](./diagrams/05-entitydataaccess-shared.drawio.svg)
 
-| Building Block                  | Responsibility                                                         |
-| ------------------------------- | ---------------------------------------------------------------------- |
-| SnakFormatter                   | Formats snaks in a client context                                      |
-| ReferenceFormatter              | Formats references in a client context                                 |
-| StatementTransclusionInteractor | Renders the main snaks associated with a given Property on an Entity   |
-| EntityTitleLookup               | Resolves a specific sitelink on a specific Item to a Title             |
-| PropertyIdResolver              | Resolved a PropertyId from input which could be a label or prefixed ID |
-| SnaksFinder                     | Find Snaks for claims in a given Entity, based on PropertyId           |
+| Building Block                  | Responsibility                                                                                             |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| SnakFormatter                   | Formats snaks in a client context                                                                          |
+| ReferenceFormatter              | Formats references in a client context                                                                     |
+| StatementTransclusionInteractor | Renders the main snaks associated with a given Property on an Entity                                       |
+| EntityTitleLookup               | Resolves a specific sitelink on a specific Item to a Title                                                 |
+| PropertyIdResolver              | Resolved a PropertyId from input which could be a [label](../overview/12-Glossary.md#label) or prefixed ID |
+| SnaksFinder                     | Find Snaks for claims in a given Entity, based on PropertyId                                               |
 
 ### ParserFunctions
 
 ![Entity Data Access Parser Functions](./diagrams/05-entitydataaccess-parserfunctions.drawio.svg)
 
-| Building Block         | Responsibility                                                          |
-| ---------------------- | ----------------------------------------------------------------------- |
-| Runner                 | Contains the methods called by MediaWiki when parser functions are used |
-| StatementGroupRenderer | Renderer for rendering a statement group                                |
+| Building Block         | Responsibility                                                             |
+| ---------------------- | -------------------------------------------------------------------------- |
+| Runner                 | Contains the methods called by MediaWiki when parser functions are used    |
+| StatementGroupRenderer | Renderer for rendering a [statement](../overview/12-Glossary.md#statement) group |
 
 ### Scribunto
 
@@ -220,7 +220,7 @@ Data Bridge is a frontend component enabling Repo edits on the Client via the Re
 
 | Building Block            | Responsibility                                                                     |
 | ------------------------- | ---------------------------------------------------------------------------------- |
-| ReplaceMutationStrategy   | Strategy for replacing a statement                                                 |
+| ReplaceMutationStrategy   | Strategy for replacing a [statement](../overview/12-Glossary.md#statement)         |
 | StatementMutationStrategy | Interface for a statement mutation strategy                                        |
 | UpdateMutationStrategy    | Strategy for updating a statement                                                  |
 | StatementMutationError    | Represents an error that can occur when mutating a statement                       |
@@ -251,7 +251,7 @@ Data Bridge is a frontend component enabling Repo edits on the Client via the Re
 | Repo API                              | Implementations of WikibaseRepo API requests                                                                                           |
 | Reading API                           | Implementations of WikibaseRepo API requests that have to do with reading from repo                                                    |
 | Writing API                           | Implementations of WikibaseRepo API requests that have to do with writing to repo                                                      |
-| ApiEntityLabelRepository              | A repository to get the label of specific entity in a specific language                                                                |
+| ApiEntityLabelRepository              | A repository to get the [label](../overview/12-Glossary.md#label) of specific entity in a specific language                            |
 | ApiPageEditPermissionErrorsRepository | A repository for determining potential permission errors when editing a page.                                                          |
 | ApiPropertyDataTypeRepository         | A repository to get the data type of a property                                                                                        |
 | ApiRenderReferencesRepository         | A repository to render reference JSON blobs into HTML strings                                                                          |
@@ -282,12 +282,12 @@ Data Bridge is a frontend component enabling Repo edits on the Client via the Re
 
 ![Special Pages Building Block Diagram](./diagrams/05-special-pages.drawio.svg)
 
-| Building Block                                           | Type/Context   | Responsibility                                                              |
-| -------------------------------------------------------- | -------------- | --------------------------------------------------------------------------- |
-| [Special Pages](../overview/12-Glossary.md#special-page) | WikibaseClient | Provide entity usage meta information                                       |
-| SpecialEntityUsage                                       | WikibaseClient | Lists client wiki pages that use a given entity ID and the aspects they use |
-| SpecialPagesWithBadges                                   | WikibaseClient | Shows a list of pages with a given badge                                    |
-| SpecialUnconnectedPages                                  | WikibaseClient | Lists client pages that are not connected to repository items               |
+| Building Block                                           | Type/Context   | Responsibility                                                               |
+| -------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------- |
+| [Special Pages](../overview/12-Glossary.md#special-page) | WikibaseClient | Provide entity usage meta information                                        |
+| SpecialEntityUsage                                       | WikibaseClient | Lists client wiki pages that use a given entity ID and the aspects they use  |
+| SpecialPagesWithBadges                                   | WikibaseClient | Shows a list of pages with a given [badge](../overview/12-Glossary.md#badge) |
+| SpecialUnconnectedPages                                  | WikibaseClient | Lists client pages that are not connected to repository items                |
 
 ## Interwiki
 

--- a/systems/WikibaseRepo/01-Introduction_and_Goals.md
+++ b/systems/WikibaseRepo/01-Introduction_and_Goals.md
@@ -15,8 +15,8 @@
 - Programmatically add new structured data to a Repo.
 - Programmatically edit existing structured data on a Repo.
 - View existing structured entity data on a Repo on mobile web.
-- Edit labels, descriptions, aliases on Repo via a mobile web interface.
-- Have Statements about external identifiers separated from other Statements in the Repo UI.
+- Edit [Labels](../overview/12-Glossary.md#label), [Descriptions](../overview/12-Glossary.md#description), [Aliases](../overview/12-Glossary.md#alias) on Repo via a mobile web interface.
+- Have [Statements](../overview/12-Glossary.md#statement) about external identifiers separated from other Statements in the Repo UI.
 - Have Statements shown in a useful order.
 - Search on the Repo for an entity.
 - Ensure the coherence of data modeling in a certain topic.
@@ -24,7 +24,7 @@
 
 ### Wikidata editor
 
-- Edit terms and sitelinks of entities without using JavaScript in a browser.
+- Edit [Terms](../overview/12-Glossary.md#term) and sitelinks of entities without using JavaScript in a browser.
 
 ### Commons editor
 

--- a/systems/WikibaseRepo/03-Context_and_Scope.md
+++ b/systems/WikibaseRepo/03-Context_and_Scope.md
@@ -4,12 +4,12 @@
 
 ![Wikibase Repo business context diagram](./diagrams/03-business-context.drawio.svg)
 
-| Neighbour              | Description                                                                                                                                                     |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| User                   | A user reading or editing the Repo's data through its web interface                                                                                             |
-| Tools and Bots         | Applications and [Bots](https://www.mediawiki.org/wiki/Manual:Bots) interacting with the Repo's data programmatically                                           |
-| Wikibase Client System | Wikibase Client Systems are MediaWiki applications consuming the Wikibase Repo's data. In Wikidata's case these would include Wikipedia, Wiktionary and others. |
-| Wikidata Query Service | A SPARQL endpoint and graphical user interface for querying the Repo's data.                                                                                    |
+| Neighbour              | Description                                                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| User                   | A user reading or editing the Repo's data through its web interface                                                                                                                                     |
+| Tools and Bots         | Applications and [Bots](https://www.mediawiki.org/wiki/Manual:Bots) interacting with the Repo's data programmatically                                                                                   |
+| Wikibase Client System | Wikibase Client Systems are [MediaWiki](../overview/12-Glossary.md#mediawiki) applications consuming the Wikibase Repo's data. In Wikidata's case these would include Wikipedia, Wiktionary and others. |
+| Wikidata Query Service | A SPARQL endpoint and graphical user interface for querying the Repo's data.                                                                                                                            |
 
 ### Technical Context
 

--- a/systems/WikibaseRepo/04-Solution_Strategy.md
+++ b/systems/WikibaseRepo/04-Solution_Strategy.md
@@ -2,7 +2,7 @@
 
 ## Developing Wikibase Repo as a MediaWiki extension
 
-One of the main requirements of Wikibase is to make data available to MediaWiki applications. This makes it a natural choice to deliver the client (= data consumer) functionality as a MediaWiki extension. (see [this section in WikibaseClient](../WikibaseClient/04-Solution_Strategy.md#developing-wikibase-client-as-a-mediawiki-extension)) The same is not necessarily the case for the Wikibase Repository, the subsystem that provides and maintains the structured data. WikibaseRepo could have been developed independently of MediaWiki, yet it was decided to use MediaWiki like a web framework and add the functionality to store and maintain structured data through the WikibaseRepo MediaWiki extension.
+One of the main requirements of Wikibase is to make data available to [MediaWiki](../overview/12-Glossary.md#mediawiki) applications. This makes it a natural choice to deliver the client (= data consumer) functionality as a MediaWiki extension. (see [this section in WikibaseClient](../WikibaseClient/04-Solution_Strategy.md#developing-wikibase-client-as-a-mediawiki-extension)) The same is not necessarily the case for the Wikibase Repository, the subsystem that provides and maintains the structured data. WikibaseRepo could have been developed independently of MediaWiki, yet it was decided to use MediaWiki like a web framework and add the functionality to store and maintain structured data through the WikibaseRepo MediaWiki extension.
 
 This came with the following benefits:
 
@@ -18,4 +18,4 @@ It also had negative consequences:
   - storing structured data in the same place Wikitext is stored
   - showing different content dependent on user settings (language)
 - binding to multiple extension points (Hooks, API actions, Special Pages, ResourceLoader, ...) of MediaWiki makes for a confusing control flow going back and forth between it and the code within the WikibaseRepo extension, where traditional web frameworks usually have one clearly defined entry and exit point
-- strong coupling to MediaWiki concepts (`Title`, `ParserOutput`, ...) slowing down development of features that aren't backed by MediaWiki (Termbox, Federated Properties)
+- strong coupling to MediaWiki concepts (`Title`, `ParserOutput`, ...) slowing down development of features that aren't backed by MediaWiki ([Termbox](../overview/12-Glossary.md#termbox), Federated Properties)

--- a/systems/WikibaseRepo/05-Building_Block_View.md
+++ b/systems/WikibaseRepo/05-Building_Block_View.md
@@ -8,31 +8,31 @@ TBA
 
 ## Action API modules
 
-| Building Block                          | Responsibility                                                                              |
-| --------------------------------------- | ------------------------------------------------------------------------------------------- |
-| wbavailablebadges                       | Get available badge items                                                                   |
-| wbcreateclaim                           | Create Wikibase claims                                                                      |
-| wbcreateredirect                        | Create Entity redirects                                                                     |
-| [wbeditentity](#action-api-edit-entity) | Create a single new Wikibase entity and modifies it with serialised information             |
-| wbformatentities                        | Format entity IDs to HTML                                                                   |
-| wbformatvalue                           | Format DataValues                                                                           |
-| wbgetclaims                             | Get Wikibase claims                                                                         |
-| wbgetentities                           | Get the data for multiple Wikibase entities                                                 |
-| wblinktitles                            | Associate two pages on two different wikis with a Wikibase item                             |
-| [wbmergeitems](#action-api-merge-items) | Merge multiple items                                                                        |
-| wbparsevalue                            | Parse values using a ValueParser                                                            |
-| wbremoveclaims                          | Remove Wikibase claims                                                                      |
-| wbremovequalifiers                      | Remove a qualifier from a claim                                                             |
-| wbremovereferences                      | Remove one or more references of the same statement                                         |
-| wbsearchentities                        | Search for entities using labels and aliases                                                |
-| wbsetaliases                            | Set the aliases for a Wikibase entity                                                       |
-| wbsetclaim                              | Create or updates an entire Statement or Claim                                              |
-| wbsetclaimvalue                         | Set the value of a Wikibase claim                                                           |
-| wbsetdescription                        | Set a description for a single Wikibase entity                                              |
-| wbsetlabel                              | Set a label for a single Wikibase entity                                                    |
-| wbsetqualifier                          | Create a qualifier or sets the value of an existing one                                     |
-| wbsetreference                          | Create a reference or sets the value of an existing one                                     |
-| wbsetsitelink                           | Associate a page on a wiki with a Wikibase item or removes an already made such association |
+| Building Block                          | Responsibility                                                                                                       |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| wbavailablebadges                       | Get available [badge](../overview/12-Glossary.md#badge) items                                                        |
+| wbcreateclaim                           | Create Wikibase claims                                                                                               |
+| wbcreateredirect                        | Create Entity redirects                                                                                              |
+| [wbeditentity](#action-api-edit-entity) | Create a single new Wikibase entity and modifies it with serialised information                                      |
+| wbformatentities                        | Format entity IDs to HTML                                                                                            |
+| wbformatvalue                           | Format DataValues                                                                                                    |
+| wbgetclaims                             | Get Wikibase claims                                                                                                  |
+| wbgetentities                           | Get the data for multiple Wikibase entities                                                                          |
+| wblinktitles                            | Associate two pages on two different wikis with a Wikibase item                                                      |
+| [wbmergeitems](#action-api-merge-items) | Merge multiple items                                                                                                 |
+| wbparsevalue                            | Parse values using a ValueParser                                                                                     |
+| wbremoveclaims                          | Remove Wikibase claims                                                                                               |
+| wbremovequalifiers                      | Remove a qualifier from a claim                                                                                      |
+| wbremovereferences                      | Remove one or more references of the same [statement](../overview/12-Glossary.md#statement)                          |
+| wbsearchentities                        | Search for entities using [labels](../overview/12-Glossary.md#label) and [aliases](../overview/12-Glossary.md#alias) |
+| wbsetaliases                            | Set the aliases for a Wikibase entity                                                                                |
+| wbsetclaim                              | Create or updates an entire Statement or Claim                                                                       |
+| wbsetclaimvalue                         | Set the value of a Wikibase claim                                                                                    |
+| wbsetdescription                        | Set a [description](../overview/12-Glossary.md#description) for a single Wikibase entity                             |
+| wbsetlabel                              | Set a [label](../overview/12-Glossary.md#label) for a single Wikibase entity                                         |
+| wbsetqualifier                          | Create a qualifier or sets the value of an existing one                                                              |
+| wbsetreference                          | Create a reference or sets the value of an existing one                                                              |
+| wbsetsitelink                           | Associate a page on a wiki with a Wikibase item or removes an already made such association                          |
 
 ### [Action API Edit Entity](https://www.wikidata.org/w/api.php?action=help&modules=wbeditentity)
 

--- a/systems/overview/12-Glossary.md
+++ b/systems/overview/12-Glossary.md
@@ -3,6 +3,22 @@
 This section contains the most important domain and technical terms used when discussing the system.
 The goal is for all consumers of the architecture documentation to have an identical understanding of the terms and not use synonyms and homonyms.
 
+## [Alias](https://www.wikidata.org/wiki/Help:Aliases)
+
+Alias (also _also known as_) is an alternative name for an [Entity](#entity). The usual or most important name is the [Label](#label). Aliases help people to find an item even if they don’t search with the label. For example, the item Q2 has the label “Earth” and aliases such as “Tellus” and “Blue Planet”. It's a type of [Term](#term).
+
+## [Badge](https://www.wikidata.org/wiki/Help:Badges)
+
+Badges are optional markers that can be attached to a sitelink to another Wikimedia page. For instance a sitelink can be marked to link to a "featured article" and/or to a "proofread" page.
+
+## [Description](https://www.wikidata.org/wiki/Help:Description)
+
+Description is a language-specific descriptive phrase for an [Entity](#entity). It provides context for the [Label](#label) (for example, there are many items about places with the label "Cambridge"). The Description therefore does not need to be unique, neither within a language or Wikidata in general, but it must be unique together with the Label. It's a type of [Term](#term).
+
+## [Label](https://www.wikidata.org/wiki/Help:Label)
+
+Label (also name) is the main name given to identify an [Entity](#entity). E.g.: the Item with the Item identifier Q7378 has the English label “elephant”. Every Entity has exactly one Label in a given human language. Labels do not need to be unique. [Descriptions](#description) and [Aliases](#alias) are used to distinguish between entities with the same Label. It's a type of [Term](#term).
+
 ## Stakeholder
 
 All persons, roles or organizations that:
@@ -23,7 +39,7 @@ A component is a software unit with a well-defined interface and explicitly spec
 
 ## [MediaWiki Extension](https://www.mediawiki.org/wiki/Manual:Extensions)
 
-Extensions are software components that administrators can add (or remove) to their MediaWiki application in order to customize how it looks and works.
+Extensions are software components that administrators can add (or remove) to their [MediaWiki](#mediawiki) application in order to customize how it looks and works.
 Examples: WikibaseClient, UniversalLanguageSelector, OAuth
 
 ## [WikibaseClient](https://www.mediawiki.org/wiki/Extension:Wikibase_Client)
@@ -36,24 +52,44 @@ Wikibase Repository is an application that provides structured [Entity](#entity)
 
 ## Wikibase Extension
 
-Wikibase Extensions are MediaWiki extensions that add further functionality to Wikibase. They depend on the Wikibase extension being installed and directly interact with it.
+Wikibase Extensions are [MediaWiki](#mediawiki) extensions that add further functionality to [Wikibase](#wikibase). They depend on the Wikibase extension being installed and directly interact with it.
 Examples: WikibaseLexeme, WikibaseMediaInfo, WikibaseImport
 
 ## Entity
 
-Entities are the top level concepts of Wikibase's data model. Items and Properties are the core Entity types of Wikibase. Other types can be added through [Wikibase extensions](#wikibase-extension), such as [Lexemes](https://www.mediawiki.org/wiki/Extension:WikibaseLexeme/Data_Model#Lexeme).
+Entities are the top level concepts of Wikibase's data model. [Items](#item) and [Properties](#property) are the core Entity types of Wikibase. Other types can be added through [Wikibase extensions](#wikibase-extension), such as [Lexemes](https://www.mediawiki.org/wiki/Extension:WikibaseLexeme/Data_Model#Lexeme).
 
 ## [Item](https://www.wikidata.org/wiki/Help:Items)
 
 In Wikidata, Items are used to represent all the things in human knowledge, including topics, concepts, and objects. For example, the "1988 Summer Olympics", "love", "Elvis Presley", and "gorilla" are all Items in Wikidata.
 
+## MediaWiki
+
+MediaWiki is the free and open-source wiki engine that is running Wikipedia and almost all other Wikimedia websites, including Wiktionary, Wikimedia Commons and Wikidata.
+
 ## [Property](https://www.wikidata.org/wiki/Help:Properties)
 
 Properties are Entities that describe a relationship between Items (or other Entities) and values of the Property. Typical Properties are _population_ (using numbers as values), _binomial name_ (using strings as values), but also _has father_ and _author of_ (both using Items as values).
 
+## [QuickStatements](https://www.wikidata.org/wiki/Help:QuickStatements)
+
+QuickStatements is a tool, that can edit Wikidata [Items](#item), based on a simple set of text commands. The tool can add and remove [Statements](#statement), [Labels](#label), Descriptions, and Aliases; as well as add statements with optional qualifiers and sources.
+
 ## [Sitelink](https://www.wikidata.org/wiki/Help:Sitelinks)
 
 Sitelinks (also known as interwiki links or interlanguage links) are special links that contain a site and a title, and go from individual [Items](#item) in Wikidata to pages on other Wikimedia sites such as Wikipedia, Wikisource and Wikivoyage.
+
+## [Statement](https://www.wikidata.org/wiki/Help:Statements)
+
+A Statement is a piece of data about an [Item](#item), recorded on the Item's page. A Statement consists of a property-value pair such as "Location: Germany", augmented by references and a rank. The term _Statement_ is often used interchangeably with _Claim_, but technically it only becomes a Statement once at least one reference has been added.
+
+## Term
+
+A term is a string value with a language code. Terms are used as [Labels](#label), [Descriptions](#description) and [Aliases](#alias) of [Entities](#entity) and are displayed in the [termbox](#termbox). They may only be plain text (i.e. not containing any wiki markup).
+
+## Termbox
+
+The termbox is the zone at the top of an [Entity](#entity) page which shows its [Labels](#label), [Descriptions](#description) and [Aliases](#alias) in different languages.
 
 ## [Interwiki Links](https://www.mediawiki.org/wiki/Manual:Interwiki)
 
@@ -64,9 +100,25 @@ Interwiki links make it possible to link to pages of (e.g.) Wikipedia, Wikibooks
 
 Lua is a programming language that can be embedded into [Wikitext](https://www.mediawiki.org/wiki/Wikitext) to programmatically enhance the content of wiki articles. It is available on most Wikimedia sites (Wikipedias, Commons, Wiktionaries, ...) via the [Scribunto MediaWiki extension](https://www.mediawiki.org/wiki/Extension:Scribunto). It's often used in templates for [Infoboxes](https://en.wikipedia.org/wiki/Help:Infobox) on Wikipedias.
 
+## [Watchlist](https://en.wikipedia.org/wiki/Help:Watchlist)
+
+A watchlist is a page which allows any logged-in user to maintain a list of "watched" pages and to generate a list of recent changes made to those pages. In this way they can keep track of, and react to, what's happening to pages they have created or are otherwise interested in.
+
+## Wikibase
+
+Wikibase is the software behind [Wikidata](#wikidata). It consists of a set of [extensions](#mediawiki-extension) to the [MediaWiki](#mediawiki) software. These extensions allow Wikidata to manage and display data in [Items](#item) and [Properties](#property).
+
+## Wikidata
+
+Wikidata is a Wikimedia project that runs an instance of [MediaWiki](#mediawiki) with the [Wikibase](#wikibase) extensions. It enables Wikidata editors to enter structured Entity data and browse pages.
+
+## Wikipedia
+
+The free, multilingual open-collaborative online encyclopedia that is run by the [MediaWiki](#mediawiki) engine and using  [WikibaseClient](#wikibaseclient) as an [extension](#mediawiki-extension) to display Entity data from [Wikidata](#wikidata).
+
 ## [Wikitext](https://en.wikipedia.org/wiki/Help:Wikitext)
 
-Wikitext, also known as Wiki markup or Wikicode, consists of the syntax and keywords used by the MediaWiki software to format a page. It's what editors work with to create and edit wiki articles.
+Wikitext, also known as Wiki markup or Wikicode, consists of the syntax and keywords used by the [MediaWiki](#mediawiki) software to format a page. It's what editors work with to create and edit wiki articles.
 
 ## Wikitext-generated content
 
@@ -74,11 +126,11 @@ This describes the content of a wiki that is generated by [Wikitext](#wikitext),
 
 ## [MediaWiki Core](https://www.mediawiki.org/wiki/Core)
 
-MediaWiki Core refers to all files that are part of the main MediaWiki package.
+MediaWiki Core refers to all files that are part of the main [MediaWiki](#mediawiki) package.
 
 ## [Special Page](https://www.mediawiki.org/wiki/Manual:Special_pages)
 
-Special pages are dynamically created MediaWiki pages, which perform a specific function, such as providing a list of pages, showing statistics or creating a form for user submitted feedback. They are located in their own namespace (_Special:_) and are not editable directly like other pages.  Developers can create new special pages. They will generally show up in the list of all special pages at [Special:SpecialPages](https://www.wikidata.org/wiki/Special:SpecialPages).
+Special pages are dynamically created [MediaWiki](#mediawiki) pages, which perform a specific function, such as providing a list of pages, showing statistics or creating a form for user submitted feedback. They are located in their own namespace (_Special:_) and are not editable directly like other pages.  Developers can create new special pages. They will generally show up in the list of all special pages at [Special:SpecialPages](https://www.wikidata.org/wiki/Special:SpecialPages).
 
 ## Gadgets
 

--- a/systems/overview/12-Glossary.md
+++ b/systems/overview/12-Glossary.md
@@ -11,61 +11,55 @@ Alias (also _also known as_) is an alternative name for an [Entity](#entity). Th
 
 Badges are optional markers that can be attached to a sitelink to another Wikimedia page. For instance a sitelink can be marked to link to a "featured article" and/or to a "proofread" page.
 
-## [Description](https://www.wikidata.org/wiki/Help:Description)
+## [Bots](https://www.wikidata.org/wiki/Wikidata:Bots)
 
-Description is a language-specific descriptive phrase for an [Entity](#entity). It provides context for the [Label](#label) (for example, there are many items about places with the label "Cambridge"). The Description therefore does not need to be unique, neither within a language or Wikidata in general, but it must be unique together with the Label. It's a type of [Term](#term).
-
-## [Label](https://www.wikidata.org/wiki/Help:Label)
-
-Label (also name) is the main name given to identify an [Entity](#entity). E.g.: the Item with the Item identifier Q7378 has the English label “elephant”. Every Entity has exactly one Label in a given human language. Labels do not need to be unique. [Descriptions](#description) and [Aliases](#alias) are used to distinguish between entities with the same Label. It's a type of [Term](#term).
-
-## Stakeholder
-
-All persons, roles or organizations that:
-
-- will use the system
-- should know the architecture
-- have to work with the architecture or with code
-- need the documentation of the architecture for their work
-- have to come up with decisions about the system or its development
-
-## Use case
-
-A textual description of the functionality provided by the system that captures actor-system interaction. It specifies how a user interacts with a system and how the system responds to the user actions.
+ Bots are tools used to make edits without the necessity of human decision-making. Bots can add interwiki links, labels, descriptions, statements, sources, and can even create items, among other things.
 
 ## Component
 
 A component is a software unit with a well-defined interface and explicitly specified dependencies. A software component can be as small as a block of reusable code, or it can be as big as an entire application depending on the level of granularity a system is being looked at.
 
-## [MediaWiki Extension](https://www.mediawiki.org/wiki/Manual:Extensions)
+## [Description](https://www.wikidata.org/wiki/Help:Description)
 
-Extensions are software components that administrators can add (or remove) to their [MediaWiki](#mediawiki) application in order to customize how it looks and works.
-Examples: WikibaseClient, UniversalLanguageSelector, OAuth
-
-## [WikibaseClient](https://www.mediawiki.org/wiki/Extension:Wikibase_Client)
-
-WikibaseClient is a [MediaWiki Extension](#mediawiki-extension) that enables the use and display of Entity data from a [Wikibase Repository](#wikibase-repository) via Lua modules or parser functions. Clients can also use centralized language links.
-
-## Wikibase Repository
-
-Wikibase Repository is an application that provides structured [Entity](#entity) data. Its core functionality is implemented as a [MediaWiki extension](#mediawiki-extension) called [WikibaseRepo](https://www.mediawiki.org/wiki/Extension:Wikibase_Repository). It can optionally contain additional [Wikibase extensions](#wikibase-extension) such as WikibaseLexeme.
-
-## Wikibase Extension
-
-Wikibase Extensions are [MediaWiki](#mediawiki) extensions that add further functionality to [Wikibase](#wikibase). They depend on the Wikibase extension being installed and directly interact with it.
-Examples: WikibaseLexeme, WikibaseMediaInfo, WikibaseImport
+Description is a language-specific descriptive phrase for an [Entity](#entity). It provides context for the [Label](#label) (for example, there are many items about places with the label "Cambridge"). The Description therefore does not need to be unique, neither within a language or Wikidata in general, but it must be unique together with the Label. It's a type of [Term](#term).
 
 ## Entity
 
 Entities are the top level concepts of Wikibase's data model. [Items](#item) and [Properties](#property) are the core Entity types of Wikibase. Other types can be added through [Wikibase extensions](#wikibase-extension), such as [Lexemes](https://www.mediawiki.org/wiki/Extension:WikibaseLexeme/Data_Model#Lexeme).
 
+## Gadgets
+
+[Gadgets](https://www.mediawiki.org/wiki/Extension:Gadgets) are made up of JavaScript and/or CSS Snippets located on pages in the MediaWiki namespace. These snippets add functionality to the wiki itself and can be enabled and disabled via preferences.
+
+## [Interwiki Links](https://www.mediawiki.org/wiki/Manual:Interwiki)
+
+Interwiki links are links to pages of other projects, using a prefixed internal link style.
+Interwiki links make it possible to link to pages of (e.g.) Wikipedia, Wikibooks, Wikinews etc. or to your wiki-project in different languages.
+
 ## [Item](https://www.wikidata.org/wiki/Help:Items)
 
 In Wikidata, Items are used to represent all the things in human knowledge, including topics, concepts, and objects. For example, the "1988 Summer Olympics", "love", "Elvis Presley", and "gorilla" are all Items in Wikidata.
 
+## [Label](https://www.wikidata.org/wiki/Help:Label)
+
+Label (also name) is the main name given to identify an [Entity](#entity). E.g.: the Item with the Item identifier Q7378 has the English label “elephant”. Every Entity has exactly one Label in a given human language. Labels do not need to be unique. [Descriptions](#description) and [Aliases](#alias) are used to distinguish between entities with the same Label. It's a type of [Term](#term).
+
+## [Lua](https://en.wikipedia.org/wiki/Wikipedia:Lua)
+
+Lua is a programming language that can be embedded into [Wikitext](https://www.mediawiki.org/wiki/Wikitext) to programmatically enhance the content of wiki articles. It is available on most Wikimedia sites (Wikipedias, Commons, Wiktionaries, ...) via the [Scribunto MediaWiki extension](https://www.mediawiki.org/wiki/Extension:Scribunto). It's often used in templates for [Infoboxes](https://en.wikipedia.org/wiki/Help:Infobox) on Wikipedias.
+
 ## MediaWiki
 
 MediaWiki is the free and open-source wiki engine that is running Wikipedia and almost all other Wikimedia websites, including Wiktionary, Wikimedia Commons and Wikidata.
+
+## [MediaWiki Core](https://www.mediawiki.org/wiki/Core)
+
+MediaWiki Core refers to all files that are part of the main [MediaWiki](#mediawiki) package.
+
+## [MediaWiki Extension](https://www.mediawiki.org/wiki/Manual:Extensions)
+
+Extensions are software components that administrators can add (or remove) to their [MediaWiki](#mediawiki) application in order to customize how it looks and works.
+Examples: WikibaseClient, UniversalLanguageSelector, OAuth
 
 ## [Property](https://www.wikidata.org/wiki/Help:Properties)
 
@@ -79,6 +73,20 @@ QuickStatements is a tool, that can edit Wikidata [Items](#item), based on a sim
 
 Sitelinks (also known as interwiki links or interlanguage links) are special links that contain a site and a title, and go from individual [Items](#item) in Wikidata to pages on other Wikimedia sites such as Wikipedia, Wikisource and Wikivoyage.
 
+## [Special Page](https://www.mediawiki.org/wiki/Manual:Special_pages)
+
+Special pages are dynamically created [MediaWiki](#mediawiki) pages, which perform a specific function, such as providing a list of pages, showing statistics or creating a form for user submitted feedback. They are located in their own namespace (_Special:_) and are not editable directly like other pages.  Developers can create new special pages. They will generally show up in the list of all special pages at [Special:SpecialPages](https://www.wikidata.org/wiki/Special:SpecialPages).
+
+## Stakeholder
+
+All persons, roles or organizations that:
+
+- will use the system
+- should know the architecture
+- have to work with the architecture or with code
+- need the documentation of the architecture for their work
+- have to come up with decisions about the system or its development
+
 ## [Statement](https://www.wikidata.org/wiki/Help:Statements)
 
 A Statement is a piece of data about an [Item](#item), recorded on the Item's page. A Statement consists of a property-value pair such as "Location: Germany", augmented by references and a rank. The term _Statement_ is often used interchangeably with _Claim_, but technically it only becomes a Statement once at least one reference has been added.
@@ -91,14 +99,13 @@ A term is a string value with a language code. Terms are used as [Labels](#label
 
 The termbox is the zone at the top of an [Entity](#entity) page which shows its [Labels](#label), [Descriptions](#description) and [Aliases](#alias) in different languages.
 
-## [Interwiki Links](https://www.mediawiki.org/wiki/Manual:Interwiki)
+## [Tools](https://www.wikidata.org/wiki/Wikidata:Tools)
 
-Interwiki links are links to pages of other projects, using a prefixed internal link style.
-Interwiki links make it possible to link to pages of (e.g.) Wikipedia, Wikibooks, Wikinews etc. or to your wiki-project in different languages.
+Tools which help when working with Wikidata. The full list of Wikidata tools can be found at [Toolforge](https://hay.toolforge.org/directory/#/search/wikidata)
 
-## [Lua](https://en.wikipedia.org/wiki/Wikipedia:Lua)
+## Use case
 
-Lua is a programming language that can be embedded into [Wikitext](https://www.mediawiki.org/wiki/Wikitext) to programmatically enhance the content of wiki articles. It is available on most Wikimedia sites (Wikipedias, Commons, Wiktionaries, ...) via the [Scribunto MediaWiki extension](https://www.mediawiki.org/wiki/Extension:Scribunto). It's often used in templates for [Infoboxes](https://en.wikipedia.org/wiki/Help:Infobox) on Wikipedias.
+A textual description of the functionality provided by the system that captures actor-system interaction. It specifies how a user interacts with a system and how the system responds to the user actions.
 
 ## [Watchlist](https://en.wikipedia.org/wiki/Help:Watchlist)
 
@@ -107,6 +114,19 @@ A watchlist is a page which allows any logged-in user to maintain a list of "wat
 ## Wikibase
 
 Wikibase is the software behind [Wikidata](#wikidata). It consists of a set of [extensions](#mediawiki-extension) to the [MediaWiki](#mediawiki) software. These extensions allow Wikidata to manage and display data in [Items](#item) and [Properties](#property).
+
+## [WikibaseClient](https://www.mediawiki.org/wiki/Extension:Wikibase_Client)
+
+WikibaseClient is a [MediaWiki Extension](#mediawiki-extension) that enables the use and display of Entity data from a [Wikibase Repository](#wikibase-repository) via Lua modules or parser functions. Clients can also use centralized language links.
+
+## Wikibase Extension
+
+Wikibase Extensions are [MediaWiki](#mediawiki) extensions that add further functionality to [Wikibase](#wikibase). They depend on the Wikibase extension being installed and directly interact with it.
+Examples: WikibaseLexeme, WikibaseMediaInfo, WikibaseImport
+
+## Wikibase Repository
+
+Wikibase Repository is an application that provides structured [Entity](#entity) data. Its core functionality is implemented as a [MediaWiki extension](#mediawiki-extension) called [WikibaseRepo](https://www.mediawiki.org/wiki/Extension:Wikibase_Repository). It can optionally contain additional [Wikibase extensions](#wikibase-extension) such as WikibaseLexeme.
 
 ## Wikidata
 
@@ -123,23 +143,3 @@ Wikitext, also known as Wiki markup or Wikicode, consists of the syntax and keyw
 ## Wikitext-generated content
 
 This describes the content of a wiki that is generated by [Wikitext](#wikitext), such as wiki pages or [messages](https://www.mediawiki.org/wiki/Help:System_message).
-
-## [MediaWiki Core](https://www.mediawiki.org/wiki/Core)
-
-MediaWiki Core refers to all files that are part of the main [MediaWiki](#mediawiki) package.
-
-## [Special Page](https://www.mediawiki.org/wiki/Manual:Special_pages)
-
-Special pages are dynamically created [MediaWiki](#mediawiki) pages, which perform a specific function, such as providing a list of pages, showing statistics or creating a form for user submitted feedback. They are located in their own namespace (_Special:_) and are not editable directly like other pages.  Developers can create new special pages. They will generally show up in the list of all special pages at [Special:SpecialPages](https://www.wikidata.org/wiki/Special:SpecialPages).
-
-## Gadgets
-
-[Gadgets](https://www.mediawiki.org/wiki/Extension:Gadgets) are made up of JavaScript and/or CSS Snippets located on pages in the MediaWiki namespace. These snippets add functionality to the wiki itself and can be enabled and disabled via preferences.
-
-## [Tools](https://www.wikidata.org/wiki/Wikidata:Tools)
-
-Tools which help when working with Wikidata. The full list of Wikidata tools can be found at [Toolforge](https://hay.toolforge.org/directory/#/search/wikidata)
-
-## [Bots](https://www.wikidata.org/wiki/Wikidata:Bots)
-
- Bots are tools used to make edits without the necessity of human decision-making. Bots can add interwiki links, labels, descriptions, statements, sources, and can even create items, among other things.

--- a/systems/overview/12-Glossary.md
+++ b/systems/overview/12-Glossary.md
@@ -5,7 +5,7 @@ The goal is for all consumers of the architecture documentation to have an ident
 
 ## [Alias](https://www.wikidata.org/wiki/Help:Aliases)
 
-Alias (also _also known as_) is an alternative name for an [Entity](#entity). The usual or most important name is the [Label](#label). Aliases help people to find an item even if they don’t search with the label. For example, the item Q2 has the label “Earth” and aliases such as “Tellus” and “Blue Planet”. It's a type of [Term](#term).
+Aliases are alternative names for [Entities](#entity) that are placed in the _Also known as_ column of the table on top of every Wikidata Item or Property page. The usual or most important name is the [Label](#label). Aliases help people to find an item even if they don’t search with the label. For example, the item Q2 has the label “Earth” and aliases such as “Tellus” and “Blue Planet”. It's a type of [Term](#term).
 
 ## [Badge](https://www.wikidata.org/wiki/Help:Badges)
 


### PR DESCRIPTION
I added some new Glossary entries and linked them from what I have found in the existing documentation (split into separate commits).

I did not add entries for:
 - Query (didn't find it in the text)
 - "structured Entity data"
 - ontology (not relevant at the moment)
 - federation (clear from the currently single occurrence, IMO)
 - sidebar (slightly modified the occurrence to make it more clear)

Bug: [T273174](https://phabricator.wikimedia.org/T273174)