### PR TITLE
Change Client constraint and reword "Wikibase extension" glossary

### DIFF
--- a/systems/WikibaseClient/02-Architecture_Constraints.md
+++ b/systems/WikibaseClient/02-Architecture_Constraints.md
@@ -1,6 +1,5 @@
 # Architecture Constraints
 
-## [MediaWiki Extensions](../overview/12-Glossary.md#mediawiki-extension)
+## MediaWiki Integration
 
-Any functionality that doesn't belong in [MediaWiki core](../overview/12-Glossary.md#mediawiki-core) has to be registered as a mediawiki extension.
-**Mediawiki extensions cannot have extensions of their own.**
+WikibaseClient makes the [Repo's](../overview/12-Glossary.md#wikibase-repository) Entity data available to MediaWiki applications such as Wikipedia. Thus, it must integrate with and extend the functionality of MediaWiki, which is best achieved through [MediaWiki extensions](../overview/12-Glossary.md#mediawiki-extension) or a [collection thereof](../overview/12-Glossary.md#wikibase-extension).

--- a/systems/overview/12-Glossary.md
+++ b/systems/overview/12-Glossary.md
@@ -121,8 +121,9 @@ WikibaseClient is a [MediaWiki Extension](#mediawiki-extension) that enables the
 
 ## Wikibase Extension
 
-Wikibase Extensions are [MediaWiki](#mediawiki) extensions that add further functionality to [Wikibase](#wikibase). They depend on the Wikibase extension being installed and directly interact with it.
-Examples: WikibaseLexeme, WikibaseMediaInfo, WikibaseImport
+Wikibase Extensions are [MediaWiki](#mediawiki) extensions that add further functionality to [WikibaseClient](#wikibaseclient) or [Wikibase Repo](#wikibase-repository). Extensions such as [WikibaseLexeme](https://www.mediawiki.org/wiki/Extension:WikibaseLexeme) that enable additional Entity types or Property datatypes on Wikibase need to be enabled both on the Repository, and on the Client. On the Repository the extension enables creating and editing these new types of data, and on the Client side the extension enables the wiki to consume and display them.
+
+Other Wikibase extensions exist only on the Repo (e.g. [WikibaseQualityConstraints](https://www.mediawiki.org/wiki/Extension:WikibaseQualityConstraints)) or only on the Client (e.g. [ArticlePlaceholder](https://www.mediawiki.org/wiki/Extension:ArticlePlaceholder)).
 
 ## Wikibase Repository
 


### PR DESCRIPTION
I changed the architecture constraint for Client quite a bit, because it contradicted the "Wikibase extension" glossary entry. Please check that it still makes sense!