### PR TITLE
Make the intro doc the landing page of each system

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -35,20 +35,19 @@ module.exports = {
             },
             {
                 text: 'Overview',
-                link: '/systems/overview/',
+                link: '/systems/overview/01-Introduction_and_Goals',
             },
             {
                 text: 'WikibaseRepo',
-                link: '/systems/WikibaseRepo/',
+                link: '/systems/WikibaseRepo/01-Introduction_and_Goals',
             },
             {
                 text: 'WikibaseClient',
-                link: '/systems/WikibaseClient/',
+                link: '/systems/WikibaseClient/01-Introduction_and_Goals',
             },
         ],
         sidebar: {
             '/systems/WikibaseRepo/': [
-                '',
                 '01-Introduction_and_Goals',
                 '02-Architecture_Constraints',
                 '03-Context_and_Scope',
@@ -62,7 +61,6 @@ module.exports = {
                 '11-Risks_and_Technical_Debt',
             ],
             '/systems/WikibaseClient/': [
-                '',
                 '01-Introduction_and_Goals',
                 '02-Architecture_Constraints',
                 '03-Context_and_Scope',
@@ -76,7 +74,6 @@ module.exports = {
                 '11-Risks_and_Technical_Debt',
             ],
             '/systems/overview/': [
-                '',
                 '01-Introduction_and_Goals',
                 '02-Architecture_Constraints',
                 '03-Context_and_Scope',

--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ Detailed documentation for arc42 can be [found here](https://docs.arc42.org/home
 
 ## Systems
 
-[Overview](./systems/overview/) provides a high level view of the whole Wikidata / Wikibase system landscape.
+[Overview](./systems/overview/01-Introduction_and_Goals.md) provides a high level view of the whole Wikidata / Wikibase system landscape.
 
 Multiple top level systems are identified.
 Subsystems are provided in the list below for convenience.
 
-- [WikibaseRepo](./systems/WikibaseRepo/)
+- [WikibaseRepo](./systems/WikibaseRepo/01-Introduction_and_Goals.md)
   - Termbox & Termbox SSR
   - EntitySchema
   - Property Suggester
   - QualityConstraints
   - WikibaseLexeme
   - WikibaseMediaInfo
-- [WikibaseClient](./systems/WikibaseClient/)
+- [WikibaseClient](./systems/WikibaseClient/01-Introduction_and_Goals.md)
   - DataBridge
   - Article Placeholder
 - QueryService ([wikitech docs](https://wikitech.wikimedia.org/wiki/Wikidata_query_service))

--- a/systems/WikibaseClient/README.md
+++ b/systems/WikibaseClient/README.md
@@ -1,3 +1,0 @@
-# WikibaseClient
-
-This documentation follows the [arc42 template](https://docs.arc42.org/home/) structure.

--- a/systems/WikibaseRepo/README.md
+++ b/systems/WikibaseRepo/README.md
@@ -1,3 +1,0 @@
-# WikibaseRepo
-
-This documentation follows the [arc42 template](https://docs.arc42.org/home/) structure.

--- a/systems/overview/03-Context_and_Scope.md
+++ b/systems/overview/03-Context_and_Scope.md
@@ -4,4 +4,4 @@
 
 ### Technical Context
 
-Wikibase extension, containing [WikibaseRepo](../WikibaseRepo/README.md), [WikibaseClient](../WikibaseClient/README.md) and more.
+Wikibase extension, containing [WikibaseRepo](../WikibaseRepo/01-Introduction_and_Goals.md), [WikibaseClient](../WikibaseClient/01-Introduction_and_Goals.md) and more.

--- a/systems/overview/README.md
+++ b/systems/overview/README.md
@@ -1,3 +1,0 @@
-# Overview
-
-This documentation follows the [arc42 template](https://docs.arc42.org/home/) structure.


### PR DESCRIPTION
Every time I click on one of the tabs in the upper right corner I land on an almost empty page saying this uses arc42.
While it could be useful info when you open it the first time, it's quite strange that the landing page is so empty.
This PR changes the landing pages of all system sections to be the `intro.md` files.