### PR TITLE
Add crosscutting concepts as seen in arc42

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -51,7 +51,6 @@ module.exports = {
                 '05-Building_Block_View',
                 '06-Runtime_View',
                 '07-Deployment_View',
-                '08-Concepts',
                 '09-Architecture_Decisions',
                 '10-Quality',
                 '11-Risks_and_Technical_Debt',
@@ -64,7 +63,6 @@ module.exports = {
                 '05-Building_Block_View',
                 '06-Runtime_View',
                 '07-Deployment_View',
-                '08-Concepts',
                 '09-Architecture_Decisions',
                 '10-Quality',
                 '11-Risks_and_Technical_Debt',
@@ -73,6 +71,7 @@ module.exports = {
                 '',
                 'Introduction_and_Goals',
                 'Context_and_Scope',
+                'Concepts',
                 'Glossary',
                 'CONTRIBUTING.md',
                 {

--- a/Concepts.md
+++ b/Concepts.md
@@ -21,7 +21,7 @@ There are several applications which are written in [Vue](https://vuejs.org/) an
 JavaScript and CSS dependencies are managed through npm. Optimization and minification of files is done through [Webpack](https://v4.webpack.js.org/).  
 There is a central Vue components library in development as part of the [Wikidata/Wikibase Design System](https://wmde.github.io/wikit/). In the future, ideally, all frontend components will be using it.
 
-The project Termbox, which delivers the terms section of an item page on mobile, uses Vue and [Nuxt](https://nuxtjs.org/) to achieve [server side rendering](https://wikitech.wikimedia.org/wiki/WMDE/Wikidata/SSR_Service).
+The project Termbox, which delivers the terms section of an item page on mobile, uses Vue and [vue-server-renderer](https://www.npmjs.com/package/vue-server-renderer) to achieve [server side rendering](https://wikitech.wikimedia.org/wiki/WMDE/Wikidata/SSR_Service).
 
 ### Internationalization (i18n)
 

--- a/Concepts.md
+++ b/Concepts.md
@@ -1,0 +1,140 @@
+# Crosscutting Concepts
+
+![Crosscutting Concepts](./diagrams/08-crosscutting-concepts.drawio.svg)
+
+## Domain concepts
+
+- [WikibaseDataModel](https://github.com/wmde/WikibaseDataModel)
+- [WikibaseDataModelJavaScript](https://github.com/wmde/WikibaseDataModelJavaScript)
+- [WikibaseDataModelTypes](https://github.com/wmde/WikibaseDataModelTypes)
+
+You can read more about Wikibase's data model in the [Glossary](./Glossary.md#entity).
+
+## User Experience concepts (UX)
+
+### User Interface
+
+User interfaces which were build prior to 2017 use either [OOUI](https://www.mediawiki.org/wiki/OOUI) or [jQuery UI](https://jqueryui.com).  
+[OOUI](https://www.mediawiki.org/wiki/OOUI) is a MediaWiki core library (developed and supported by the WMF) that contains a set of ready-to-use widgets, layouts, windows and a server-side component that generates compatible output in PHP for cases where JavaScript is not supported.
+
+There are several applications which are written in [Vue](https://vuejs.org/) and [TypeScript](https://www.typescriptlang.org/).  
+JavaScript and CSS dependencies are managed through npm. Optimization and minification of files is done through [Webpack](https://v4.webpack.js.org/).  
+There is a central Vue components library in development as part of the [Wikidata/Wikibase Design System](https://wmde.github.io/wikit/). In the future, ideally, all frontend components will be using it.
+
+The project Termbox, which delivers the terms section of an item page on mobile, uses Vue and [Nuxt](https://nuxtjs.org/) to achieve [server side rendering](https://wikitech.wikimedia.org/wiki/WMDE/Wikidata/SSR_Service).
+
+### Internationalization (i18n)
+
+The system is made usable in international settings in the following ways:
+
+- by providing internationalized content via [mediawiki's i18n mechanism](https://www.mediawiki.org/wiki/Localisation)
+- by designing and developing for both left-to-right and right-to-left scripts
+
+## Security concepts
+
+The development conforms to established [security best practices](https://www.mediawiki.org/wiki/Security_for_developers).
+
+Security code review is performed by [WMF's Security Team](https://www.mediawiki.org/wiki/Wikimedia_Security_Team) for every new feature.
+
+## Architecture and design patterns
+
+Recurring patterns within the system.  
+TBD
+
+## “Under-the-hood” concepts
+
+### Persistency
+
+How / where to store and retrieve data.  
+TBD
+
+### Process control
+
+TBD
+
+### Communication and integration
+
+How to integrate with other systems, how to communicate (i.e. sync, async, pub-sub…)  
+TBD
+
+### Exception and error handling
+
+What errors to handle, how to handle exceptional situations.  
+TBD.
+
+### Parallization and threading
+
+How to parallelize tasks, how to create/spawn/manage processes.  
+TBD.
+
+### Plausibility checks and validation
+
+i.e. client-side validation, how to verify/check data, input, results.  
+TBD.
+
+### Business rules
+
+i.e. how to use a rule-engine, how to implement/configure business rules, how to change those…  
+TBD.
+
+### Batch processing
+
+How to process data in batches (i.e. offline processing).  
+TBD.
+
+### Reporting
+
+How to create reports, how to gather the required data, how to render the results.  
+TBD.
+
+## Development concepts
+
+### Build, test, deploy
+
+TBD
+
+### Code generation
+
+TBD
+
+### Migration
+
+TBD
+
+### Configurability
+
+TBD
+
+## Operational concepts
+
+### Administration
+
+TBD
+
+### Management
+
+TBD
+
+### Disaster-Recovery
+
+TBD
+
+### Scaling
+
+TBD
+
+### Clustering
+
+TBD
+
+### Monitoring, Logging
+
+TBD
+
+### High Availability
+
+TBD
+
+### Load balancing
+
+TBD

--- a/diagrams/08-crosscutting-concepts.drawio.svg
+++ b/diagrams/08-crosscutting-concepts.drawio.svg
@@ -1,0 +1,156 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="732px" height="362px" viewBox="-0.5 -0.5 732 362" content="&lt;mxfile host=&quot;ec5cc192-80b4-4f13-b9f9-2ebbb6e6d326&quot; modified=&quot;2021-02-11T16:54:08.164Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.53.0 Chrome/87.0.4280.141 Electron/11.2.1 Safari/537.36&quot; version=&quot;14.2.4&quot; etag=&quot;gwxHPhZGPiwzEnM-9ACG&quot; type=&quot;embed&quot;&gt;&lt;diagram id=&quot;077FBmaMYnTsPEMaRids&quot; name=&quot;Page-1&quot;&gt;5ZlLc9owEMc/DdeO349jCml76TQzTKfJUbUXW1MjMUIE6KevhCXbspyUZAwh4ZKwq4el/f290sLEny53Xxlald9pDtXEc/LdxJ9NPM8NnFD8k5597Qkjp3YUDOeqU+uY47+gnLrbBuewNjpySiuOV6Yzo4RAxg0fYoxuzW4LWplPXaECLMc8Q5Xt/YVzXtZez3GctuEb4KLUj050yxLp3sqxLlFOtx2Xfzvxp4xSXn9a7qZQyejpwNTjvjzR2qyMAeHHDPDqAY+o2qjNiYev19mGc0wK0TKlJIMVX6vl8r0OAqMbkoOcxp34n7cl5jBfoUy2bgV24Sv5slLNC1xVU1pRdhjr5wiSRSb8a87oH+i0RFkCvxdNiw6vJ+eghCstuJG21XpcZXdmcpxgmqbCr3YIjMPuySi5TeyFaoEugbO96KIHNGiVYpNQ2duWvxsqWZcd9LHqh5TkimbuFor4oLgMM/ItRj/XwITndrcChkEAuiw6wXnpRH5ownEH4OgXrgsnGAFOYMH5IaAgjim52LfnzHxcLzABpekZAYUWoBk8QkVXS7n8a+YSJyYW1znnixNZXOaQbRjmcoWI5OLvHC2A76+aUdR/dYIjEYUjIIotRDcsk+HO+IZBg0ncxXBBDtviHBi57mwX++ZVIRpKdv7AVWEMYol9VRCBl3cFXkpgJaX5VdOxzqLYO/KF8kfAo/Nr9zCiS4TJVTNJox4S55xI7ArIggEkv5Flo7AIJWAGX2yS7e+F4WjjQRqfQm3Odt3G2V5bO8zv9Rzicz0qDpXZjpKGHlQvDXKrPu3FWiyfblgGRh7niBWgennDRDoRD585VBhU4ob7aC5iiIJ6wh3F8q6lgSdpr5pKeiDrxatR3eq1N1FzGuqJ+oqot2xNdBBFs+3jdGJXYS/UySDvU+D2PwRbu+ZOTwfXruIuFW70lnDj2ESS9u8sFwnXrgBfm+HbpP7QbXtRhj+FKMILS/Cpa9J1He8dZHi7Ih1HJ86ROmm18dBRzZg60VguRijv8iZgl8UfLZ94tkySt5SJ60b/OS6OPni8/kwnFIpdjb9QKE1iSA+1Vgs9cp7HLo07YFisFlhXTK9IT6NJKHhTCXm9Myntf4n5egmNdncRZvvTX929/QXVv/0H&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <rect x="366" y="161" width="155" height="70" rx="10.5" ry="10.5" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 153px; height: 1px; padding-top: 196px; margin-left: 367px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: #004C99; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Crosscutting Concepts
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="444" y="201" fill="#004C99" font-family="Helvetica" font-size="16px" text-anchor="middle" font-weight="bold">
+                    Crosscutting Concep...
+                </text>
+            </switch>
+        </g>
+        <rect x="1" y="121" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 141px; margin-left: 2px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #004C99; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                User Experience
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="61" y="145" fill="#004C99" font-family="Helvetica" font-size="14px" text-anchor="middle" font-weight="bold">
+                    User Experience
+                </text>
+            </switch>
+        </g>
+        <rect x="611" y="301" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 321px; margin-left: 612px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #004C99; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Operation Concepts
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="671" y="325" fill="#004C99" font-family="Helvetica" font-size="14px" text-anchor="middle" font-weight="bold">
+                    Operation Concepts
+                </text>
+            </switch>
+        </g>
+        <rect x="151" y="321" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 341px; margin-left: 152px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #004C99; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Development
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="211" y="345" fill="#004C99" font-family="Helvetica" font-size="14px" text-anchor="middle" font-weight="bold">
+                    Development
+                </text>
+            </switch>
+        </g>
+        <rect x="11" y="251" width="120" height="50" rx="7.5" ry="7.5" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 276px; margin-left: 12px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #004C99; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Security and Safety
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="71" y="280" fill="#004C99" font-family="Helvetica" font-size="14px" text-anchor="middle" font-weight="bold">
+                    Security and Safe...
+                </text>
+            </switch>
+        </g>
+        <rect x="96" y="1" width="135" height="50" rx="7.5" ry="7.5" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 133px; height: 1px; padding-top: 26px; margin-left: 97px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #004C99; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Architecture and design patterns
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="164" y="30" fill="#004C99" font-family="Helvetica" font-size="14px" text-anchor="middle" font-weight="bold">
+                    Architecture and de...
+                </text>
+            </switch>
+        </g>
+        <rect x="611" y="31" width="120" height="30" rx="4.5" ry="4.5" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 46px; margin-left: 612px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #004C99; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Under the hood
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="671" y="50" fill="#004C99" font-family="Helvetica" font-size="14px" text-anchor="middle" font-weight="bold">
+                    Under the hood
+                </text>
+            </switch>
+        </g>
+        <rect x="331" y="11" width="120" height="30" rx="4.5" ry="4.5" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 26px; margin-left: 332px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #004C99; line-height: 1.2; pointer-events: all; font-weight: bold; white-space: normal; word-wrap: normal; ">
+                                Domain
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="391" y="30" fill="#004C99" font-family="Helvetica" font-size="14px" text-anchor="middle" font-weight="bold">
+                    Domain
+                </text>
+            </switch>
+        </g>
+        <path d="M 231 38.5 L 366 196" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 121 141 L 366 201" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 131 276 L 366 201" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 271 341 L 443.5 231" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 391 41 L 443.5 161" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 521 196 L 671 61" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 520.84 203.35 L 671 301" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/systems/WikibaseClient/08-Concepts.md
+++ b/systems/WikibaseClient/08-Concepts.md
@@ -1,1 +1,0 @@
-# Crosscutting Concepts

--- a/systems/WikibaseRepo/08-Concepts.md
+++ b/systems/WikibaseRepo/08-Concepts.md
@@ -1,1 +1,0 @@
-# Crosscutting Concepts


### PR DESCRIPTION
Crosscutting concepts is a pretty big section in arc42. I think it should be filled in gradually like the Glossary.

Please look at [the docs](https://docs.arc42.org/section-8/) and [this tip](https://docs.arc42.org/tips/8-10/).

https://deploy-preview-105--wikidata-wikibase-architecture.netlify.app/Concepts.html
