### PR TITLE
Gitignore dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-.vuepress/public
+.vuepress/dist
 .idea


### PR DESCRIPTION
I just ran `npm run build` locally which resulted in untracked files flying around. I think this was a typo "public" <-> "dist"? :thinking: 