### PR TITLE
Link Repo & Client Architecture decisions to ADRs

### DIFF
--- a/systems/WikibaseClient/09-Architecture_Decisions.md
+++ b/systems/WikibaseClient/09-Architecture_Decisions.md
@@ -1,1 +1,5 @@
 # Architecture Decisions
+
+## ADRs
+
+Since 2018 architecture decisions concerning Wikibase are recorded as ADRs. They are stored within the Wikibase code repository and can be found on the [official documentation website](https://doc.wikimedia.org/Wikibase/master/php/md_docs_adr_index.html).

--- a/systems/WikibaseRepo/09-Architecture_Decisions.md
+++ b/systems/WikibaseRepo/09-Architecture_Decisions.md
@@ -1,9 +1,5 @@
 # Architecture Decisions
 
-## Early architecture decisions
-
-This section contains retrospectively documented decisions that were made before the practice of recording them in ADRs was established. Some knowledge of the decision context likely went missing over time, so the reasoning is speculative to some degree.
-
 ## ADRs
 
 Since 2018 architecture decisions concerning Wikibase are recorded as ADRs. They are stored within the Wikibase code repository and can be found on the [official documentation website](https://doc.wikimedia.org/Wikibase/master/php/md_docs_adr_index.html).


### PR DESCRIPTION
Remove "Early Architecture Decisions" from Repo, since they have been
moved to Solution Strategy and link the Client section to existing ADRs.

Bug: [T274529](https://phabricator.wikimedia.org/T274529)