### PR TITLE
Cache npm dependencies in GH actions

### DIFF
--- a/.github/workflows/node.branch-preview.yml
+++ b/.github/workflows/node.branch-preview.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-node@v2.4.1
       with:
         node-version: 16.x
+        cache: npm
     - run: npm install
     - run: npm run build
     - name: Deploy branch preview to Netlify

--- a/.github/workflows/node.deploy.yml
+++ b/.github/workflows/node.deploy.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-node@v2.4.1
       with:
         node-version: 16.x
+        cache: npm
     - name: vuepress-deploy
       uses: jenkey2011/vuepress-deploy@master
       env:

--- a/.github/workflows/node.test.yml
+++ b/.github/workflows/node.test.yml
@@ -13,6 +13,7 @@ jobs:
       uses: actions/setup-node@v2.4.1
       with:
         node-version: 16.x
+        cache: npm
     - run: npm install
     - run: npm run test
 
@@ -26,5 +27,6 @@ jobs:
       uses: actions/setup-node@v2.4.1
       with:
         node-version: 16.x
+        cache: npm
     - run: npm install
     - run: npm run build


### PR DESCRIPTION
This should result in faster CI runs. See:
https://github.com/actions/setup-node#caching-packages-dependencies