### PR TITLE
Don't install node for vuepress deploy action

### DIFF
--- a/.github/workflows/node.deploy.yml
+++ b/.github/workflows/node.deploy.yml
@@ -10,11 +10,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
 
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v2.4.1
-      with:
-        node-version: 16.x
-        cache: npm
     - name: vuepress-deploy
       uses: jenkey2011/vuepress-deploy@master
       env:


### PR DESCRIPTION
It doesn't seem to have an effect and currently fails.

The [usage example](https://github.com/jenkey2011/vuepress-deploy#usage) does not install node either. Looks like it always runs whatever node version [its dockerfile](https://github.com/jenkey2011/vuepress-deploy/blob/master/Dockerfile) uses.