### PR TITLE
Replace deprecated set-output with environment variable

### DIFF
--- a/.github/workflows/node.branch-preview.yml
+++ b/.github/workflows/node.branch-preview.yml
@@ -19,13 +19,12 @@ jobs:
     - run: npm install
     - run: npm run build
     - name: Deploy branch preview to Netlify
-      id: netlify_deploy
-      run: echo "::set-output name=url::$(npx -p netlify-cli
+      run: echo "NETLIFY_DEPLOY_URL=$(npx -p netlify-cli
         netlify deploy --dir=.vuepress/dist --json
         --alias $(echo '${{ github.ref }}' | shasum | awk '{print $1}' | head -c 10 )
-        | jq '.deploy_url' --raw-output)"
+        | jq '.deploy_url' --raw-output)" >> $GITHUB_ENV 
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
     - name: Print deploy URL
-      run: echo ${{ steps.netlify_deploy.outputs.url }}
+      run: echo ${{ env.NETLIFY_DEPLOY_URL }}


### PR DESCRIPTION
Bug: [T322548](https://phabricator.wikimedia.org/T322548)

It can be seen here:
https://github.com/wmde/wikidata-wikibase-architecture/actions/runs/3800731809/jobs/6464480764#step:7:2